### PR TITLE
Chore/update coverlet msbuild 10.0.0

### DIFF
--- a/tests/POIneer.Render.ContractTests/POIneer.Render.ContractTests.csproj
+++ b/tests/POIneer.Render.ContractTests/POIneer.Render.ContractTests.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/POIneer.Render.ContractTests/packages.lock.json
+++ b/tests/POIneer.Render.ContractTests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.4, )",
-        "resolved": "6.0.4",
-        "contentHash": "Qa7Hg+wrOMDKpXVn2dw4Wlun490bIWsFW0fdNJQFJLZnbU27MCP0HJ2mPgS+3EQBQUb0zKlkwiQzP+j38Hc3Iw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "pmUxktztlMnsIvgHjzxG3fHRAXpqmZSA+W8dIsbVMfwI01SnBndrBIOE3Stg6987+o7HjBa62C4q5um3Ia6d9g=="
       },
       "FluentAssertions": {
         "type": "Direct",

--- a/tests/POIneer.Render.IntegrationTests/POIneer.Render.IntegrationTests.csproj
+++ b/tests/POIneer.Render.IntegrationTests/POIneer.Render.IntegrationTests.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/POIneer.Render.IntegrationTests/packages.lock.json
+++ b/tests/POIneer.Render.IntegrationTests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.4, )",
-        "resolved": "6.0.4",
-        "contentHash": "Qa7Hg+wrOMDKpXVn2dw4Wlun490bIWsFW0fdNJQFJLZnbU27MCP0HJ2mPgS+3EQBQUb0zKlkwiQzP+j38Hc3Iw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "pmUxktztlMnsIvgHjzxG3fHRAXpqmZSA+W8dIsbVMfwI01SnBndrBIOE3Stg6987+o7HjBa62C4q5um3Ia6d9g=="
       },
       "FluentAssertions": {
         "type": "Direct",

--- a/tests/POIneer.Render.UnitTests/POIneer.Render.UnitTests.csproj
+++ b/tests/POIneer.Render.UnitTests/POIneer.Render.UnitTests.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/POIneer.Render.UnitTests/packages.lock.json
+++ b/tests/POIneer.Render.UnitTests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.4, )",
-        "resolved": "6.0.4",
-        "contentHash": "Qa7Hg+wrOMDKpXVn2dw4Wlun490bIWsFW0fdNJQFJLZnbU27MCP0HJ2mPgS+3EQBQUb0zKlkwiQzP+j38Hc3Iw=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "pmUxktztlMnsIvgHjzxG3fHRAXpqmZSA+W8dIsbVMfwI01SnBndrBIOE3Stg6987+o7HjBa62C4q5um3Ia6d9g=="
       },
       "FluentAssertions": {
         "type": "Direct",


### PR DESCRIPTION
## 📦 Align `coverlet.msbuild` to 10.0.0 across all test projects

### 🔍 Summary

This PR updates and aligns the `coverlet.msbuild` package version to **10.0.0** across all test projects.

Originally, Dependabot updated only a single test project, which resulted in inconsistent versions within the solution. This change ensures a **consistent and predictable test/coverage setup**.

---

### 🎯 Motivation

* Avoid version drift between test projects
* Ensure consistent behavior for code coverage across the solution
* Reduce potential CI/CD inconsistencies (e.g., Jenkins coverage reporting)
* Prepare the codebase for future improvements (e.g., Central Package Management)

---

### 🔧 Changes

* Updated all occurrences of:

  ```xml
  <PackageReference Include="coverlet.msbuild" Version="..." />
  ```

  → to:

  ```xml
  <PackageReference Include="coverlet.msbuild" Version="10.0.0" />
  ```

* No functional changes to application code

---

### ✅ Validation

* `dotnet restore` executed successfully
* `dotnet build` completed without errors
* `dotnet test` passed for all test projects
* Code coverage collection still working as expected

---

### ⚠️ Notes

* This is a **major version upgrade (6.x → 10.0.0)**
  No breaking issues were observed during local testing.

---

### 🚀 Next Steps (optional, follow-up)

* Introduce **Central Package Management** (`Directory.Packages.props`) to manage package versions in a single place

---

### ✅ Checklist

* [x] All test projects use the same `coverlet.msbuild` version
* [x] Local build & tests successful
* [x] No breaking changes observed
* [x] Self-review completed
