### PR TITLE
Bump FluentAssertions from 8.8.0 to 8.9.0

### DIFF
--- a/tests/POIneer.Render.IntegrationTests/POIneer.Render.IntegrationTests.csproj
+++ b/tests/POIneer.Render.IntegrationTests/POIneer.Render.IntegrationTests.csproj
@@ -23,7 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/tests/POIneer.Render.IntegrationTests/packages.lock.json
+++ b/tests/POIneer.Render.IntegrationTests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "FluentAssertions": {
         "type": "Direct",
-        "requested": "[8.8.0, )",
-        "resolved": "8.8.0",
-        "contentHash": "m0kwcqBwvVel03FuMa7Ozo/oTaxYbjeNlcOhQFkyQpwX/8wks6RNl/Jnn58DCZVs6c2oG1RsCZw7HfKSaxLm3w=="
+        "requested": "[8.9.0, )",
+        "resolved": "8.9.0",
+        "contentHash": "Y5RDjxaVlxWX2yy0X/ay1tJjSKMOtjepSb83mmfngFS63hm3LsoZNj6nhmImzm1ifRmpF9ouvmHjx9nNwnkpDg=="
       },
       "JunitXml.TestLogger": {
         "type": "Direct",

--- a/tests/POIneer.Render.UnitTests/POIneer.Render.UnitTests.csproj
+++ b/tests/POIneer.Render.UnitTests/POIneer.Render.UnitTests.csproj
@@ -24,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.8.0" />
+        <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/tests/POIneer.Render.UnitTests/packages.lock.json
+++ b/tests/POIneer.Render.UnitTests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "FluentAssertions": {
         "type": "Direct",
-        "requested": "[8.8.0, )",
-        "resolved": "8.8.0",
-        "contentHash": "m0kwcqBwvVel03FuMa7Ozo/oTaxYbjeNlcOhQFkyQpwX/8wks6RNl/Jnn58DCZVs6c2oG1RsCZw7HfKSaxLm3w=="
+        "requested": "[8.9.0, )",
+        "resolved": "8.9.0",
+        "contentHash": "Y5RDjxaVlxWX2yy0X/ay1tJjSKMOtjepSb83mmfngFS63hm3LsoZNj6nhmImzm1ifRmpF9ouvmHjx9nNwnkpDg=="
       },
       "JunitXml.TestLogger": {
         "type": "Direct",


### PR DESCRIPTION
## ⬆️ Bump `FluentAssertions` from 8.8.0 to 8.9.0

### 🔍 Summary

This PR updates the `FluentAssertions` package from **8.8.0** to **8.9.0** across the solution.

This is a **minor version upgrade**, bringing small improvements and fixes without introducing breaking changes.

---

### 🎯 Motivation

* Keep dependencies up to date
* Benefit from bug fixes and minor improvements
* Maintain compatibility with the latest .NET ecosystem
* Reduce technical debt and future upgrade effort

---

### 🔧 Changes

* Updated:

  ```xml
  <PackageReference Include="FluentAssertions" Version="8.8.0" />
  ```

  → to:

  ```xml
  <PackageReference Include="FluentAssertions" Version="8.9.0" />
  ```

* No changes to test logic or assertions required

---

### ✅ Validation

* `dotnet restore` completed successfully
* `dotnet build` succeeded without warnings/errors
* `dotnet test` passed for all test projects

---

### ⚠️ Notes

* This is a **non-breaking minor update**
* No behavioral changes observed during testing

---

### ✅ Checklist

* [x] Dependency updated
* [x] All tests pass locally
* [x] No code changes required
* [x] Self-review completed
