### PR TITLE
Bump dotnet-reportgenerator-globaltool from 5.5.4 to 5.5.5

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.4",
+      "version": "5.5.5",
       "commands": [
         "reportgenerator"
       ],


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: dotnet-reportgenerator-globaltool dependency-version: 5.5.5 dependency-type: direct:production update-type: version-update:semver-patch ...

## 📋 Description

* upgrade dotnet-reportgenerator-globaltool from 5.5.4 to 5.5.5

---

## 🧪 How to Test
dotnet clean, dotnet test


---

## ✅ Checklist

- [x] Build successful
- [x] All tests pass locally
- [x] No breaking changes observed
- [x] CI green
---

## ⚠️ Breaking Changes

* None

---

## ⚠️ Notes
- This PR replaces the original Dependabot PR to allow clean rebasing and validation
- No functional changes expected (dependency update only)

## 📸 Screenshots (if applicable)

* none
