### PR TITLE
Bump dotnet-reportgenerator-globaltool from 5.5.5 to 5.5.7

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.5",
+      "version": "5.5.7",
       "commands": [
         "reportgenerator"
       ],


### PR DESCRIPTION
## 📋 Summary

This pull request updates one or more dependencies managed by Dependabot and verifies that the update is safe for the project.

## 🔗 Related

- Related Dependabot PR: https://github.com/choXberg/poineer-render/pull/77

## 📦 Dependency Changes

Updated [dotnet-reportgenerator-globaltool](https://github.com/danielpalme/ReportGenerator) from 5.5.5 to 5.5.7.

## ✅ Validation

- [x] `dotnet restore` completed successfully
- [x] `dotnet build` succeeded without warnings
- [x] `dotnet test` succeeded
- [x] No breaking API or behavior changes were detected
- [x] Lock files / tool manifests were reviewed
- [x] CI passed

## ⚠️ Risks

- [x] Low risk patch update

## 🧪 Manual Checks

- [x] Application starts successfully
- [x] Relevant integration path tested
- [x] Coverage/reporting still works
- [x] Tooling still works in CI

## 💥 Breaking Changes

None

## 📝 Additional Notes

None