### PR TITLE
Feature/query poi by amenity and location

### DIFF
--- a/src/POIneer.Render/Domain/Models/BoundingBox.cs
+++ b/src/POIneer.Render/Domain/Models/BoundingBox.cs
@@ -1,0 +1,5 @@
+namespace POIneer.Render.Domain.Models;
+
+public sealed record BoundingBox(
+    GeoPoint NorthWest,
+    GeoPoint SouthEast);

--- a/src/POIneer.Render/Domain/Repositories/IPoiRepository.cs
+++ b/src/POIneer.Render/Domain/Repositories/IPoiRepository.cs
@@ -16,10 +16,8 @@ public interface IPoiRepository
         int limit = 100,
         CancellationToken ct = default);
 
-    Task<IReadOnlyList<Poi>> GetByLocationAsync(
-        double latitude,
-        double longitude,
-        double radiusInMeters,
+    Task<IReadOnlyList<Poi>> GetByBoundingBoxAsync(
+        BoundingBox boundingBox,
         int limit = 100,
         CancellationToken ct = default);
 }

--- a/src/POIneer.Render/Domain/Repositories/IPoiRepository.cs
+++ b/src/POIneer.Render/Domain/Repositories/IPoiRepository.cs
@@ -6,4 +6,20 @@ public interface IPoiRepository
 {
     Task AddAsync(Poi poi, CancellationToken ct = default);
     Task<IReadOnlyList<Poi>> GetAllAsync(int limit = 100, CancellationToken ct = default);
+
+    Task<IReadOnlyList<Poi>> GetByAmenityAsync(
+        string amenity,
+        int limit = 100,
+        CancellationToken ct = default);
+    Task<IReadOnlyList<Poi>> GetByNameAsync(
+        string name,
+        int limit = 100,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<Poi>> GetByLocationAsync(
+        double latitude,
+        double longitude,
+        double radiusInMeters,
+        int limit = 100,
+        CancellationToken ct = default);
 }

--- a/src/POIneer.Render/Infrastructure/Sqlite/PoiTable.cs
+++ b/src/POIneer.Render/Infrastructure/Sqlite/PoiTable.cs
@@ -1,0 +1,13 @@
+namespace POIneer.Render.Infrastructure.Sqlite;
+
+internal static class PoiTable
+{
+    public const string Name = "poi";
+
+    public const string Id = "id";
+    public const string OsmId = "osm_id";
+    public const string NameColumn = "name";
+    public const string Amenity = "amenity";
+    public const string Latitude = "latitude";
+    public const string Longitude = "longitude";
+}

--- a/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
+++ b/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
@@ -88,16 +88,7 @@ public sealed class SqlitePoiRepository : IPoiRepository
 
         while (await reader.ReadAsync(cancellationToken: ct))
         {
-            var poi = new Poi(
-                Id: reader.GetInt64(IdOrdinal),
-                OsmId: reader.GetInt64(OsmIdOrdinal),
-                Name: reader.IsDBNull(NameOrdinal) ? null : reader.GetString(NameOrdinal),
-                Amenity: reader.IsDBNull(AmenityOrdinal) ? null : reader.GetString(AmenityOrdinal),
-                Location: new GeoPoint(
-                    Latitude: reader.GetDouble(LatitudeOrdinal),
-                    Longitude: reader.GetDouble(LongitudeOrdinal))
-            );
-
+            var poi = MapPoi(reader);
             result.Add(poi);
         }
 
@@ -146,16 +137,7 @@ public sealed class SqlitePoiRepository : IPoiRepository
 
         while (await reader.ReadAsync(cancellationToken: ct))
         {
-            var poi = new Poi(
-                Id: reader.GetInt64(IdOrdinal),
-                OsmId: reader.GetInt64(OsmIdOrdinal),
-                Name: reader.IsDBNull(NameOrdinal) ? null : reader.GetString(NameOrdinal),
-                Amenity: reader.IsDBNull(AmenityOrdinal) ? null : reader.GetString(AmenityOrdinal),
-                Location: new GeoPoint(
-                    Latitude: reader.GetDouble(LatitudeOrdinal),
-                    Longitude: reader.GetDouble(LongitudeOrdinal))
-            );
-
+            var poi = MapPoi(reader);
             result.Add(poi);
         }
 
@@ -167,9 +149,64 @@ public sealed class SqlitePoiRepository : IPoiRepository
         throw new NotImplementedException();
     }
 
-    public Task<IReadOnlyList<Poi>> GetByNameAsync(string name, int limit = 100, CancellationToken ct = default)
+    public async Task<IReadOnlyList<Poi>> GetByNameAsync(string name, int limit = 100, CancellationToken ct = default)
     {
-        throw new NotImplementedException();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Name must be a non-empty string.", nameof(name));
+        }
+
+        if (limit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be greater than zero.");
+        }
+
+        var result = new List<Poi>();
+
+        await using var connection = _connectionFactory();
+        await connection.OpenAsync(cancellationToken: ct);
+
+        var sql = $"""
+            SELECT 
+                {PoiTable.Id}, 
+                {PoiTable.OsmId}, 
+                {PoiTable.NameColumn}, 
+                {PoiTable.Amenity}, 
+                {PoiTable.Latitude}, 
+                {PoiTable.Longitude}
+            FROM 
+                {PoiTable.Name}
+            WHERE
+                {PoiTable.NameColumn} = @name
+            ORDER BY 
+                {PoiTable.Id}
+            LIMIT @limit;
+            """;
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("@name", name);
+        command.Parameters.AddWithValue("@limit", limit);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken: ct);
+
+        while (await reader.ReadAsync(cancellationToken: ct))
+        {
+            var poi = MapPoi(reader);
+            result.Add(poi);
+        }
+        return result;
     }
 
+    private static Poi MapPoi(SqliteDataReader reader)
+    {
+        return new Poi(
+            Id: reader.GetInt64(IdOrdinal),
+            OsmId: reader.GetInt64(OsmIdOrdinal),
+            Name: reader.IsDBNull(NameOrdinal) ? null : reader.GetString(NameOrdinal),
+            Amenity: reader.IsDBNull(AmenityOrdinal) ? null : reader.GetString(AmenityOrdinal),
+            Location: new GeoPoint(
+                Latitude: reader.GetDouble(LatitudeOrdinal),
+                Longitude: reader.GetDouble(LongitudeOrdinal)));
+    }
 }

--- a/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
+++ b/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
@@ -198,10 +198,7 @@ public sealed class SqlitePoiRepository : IPoiRepository
         int limit = 100,
         CancellationToken ct = default)
     {
-        if (boundingBox is null)
-        {
-            throw new ArgumentNullException(nameof(boundingBox));
-        }
+        ArgumentNullException.ThrowIfNull(boundingBox);
 
         if (limit <= 0)
         {

--- a/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
+++ b/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
@@ -144,11 +144,6 @@ public sealed class SqlitePoiRepository : IPoiRepository
         return result;
     }
 
-    public Task<IReadOnlyList<Poi>> GetByLocationAsync(double latitude, double longitude, double radiusInMeters, int limit = 100, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
-
     public async Task<IReadOnlyList<Poi>> GetByNameAsync(string name, int limit = 100, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -195,6 +190,58 @@ public sealed class SqlitePoiRepository : IPoiRepository
             var poi = MapPoi(reader);
             result.Add(poi);
         }
+        return result;
+    }
+
+    public async Task<IReadOnlyList<Poi>> GetByBoundingBoxAsync(
+        BoundingBox boundingBox,
+        int limit = 100,
+        CancellationToken ct = default)
+    {
+        if (limit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be greater than zero.");
+        }
+
+        var result = new List<Poi>();
+        await using var connection = _connectionFactory();
+        await connection.OpenAsync(cancellationToken: ct);
+        var sql = $"""
+            SELECT 
+                {PoiTable.Id}, 
+                {PoiTable.OsmId}, 
+                {PoiTable.NameColumn}, 
+                {PoiTable.Amenity}, 
+                {PoiTable.Latitude}, 
+                {PoiTable.Longitude}
+            FROM 
+                {PoiTable.Name}
+            WHERE
+                {PoiTable.Latitude} <= @northWestLat AND
+                {PoiTable.Latitude} >= @southEastLat AND
+                {PoiTable.Longitude} >= @northWestLon AND
+                {PoiTable.Longitude} <= @southEastLon
+            ORDER BY 
+                {PoiTable.Id}
+            LIMIT @limit;
+            """;
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("@northWestLat", boundingBox.NorthWest.Latitude);
+        command.Parameters.AddWithValue("@southEastLat", boundingBox.SouthEast.Latitude);
+        command.Parameters.AddWithValue("@northWestLon", boundingBox.NorthWest.Longitude);
+        command.Parameters.AddWithValue("@southEastLon", boundingBox.SouthEast.Longitude);
+        command.Parameters.AddWithValue("@limit", limit);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken: ct);
+
+        while (await reader.ReadAsync(cancellationToken: ct))
+        {
+            var poi = MapPoi(reader);
+            result.Add(poi);
+        }
+
         return result;
     }
 

--- a/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
+++ b/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
@@ -30,8 +30,13 @@ public sealed class SqlitePoiRepository : IPoiRepository
         await using var connection = _connectionFactory();
         await connection.OpenAsync(cancellationToken: ct);
 
-        const string sql = """
-            INSERT INTO poi (osm_id, name, amenity, latitude, longitude)
+        const string sql = $"""
+            INSERT INTO {PoiTable.Name} (
+                {PoiTable.OsmId}, 
+                {PoiTable.NameColumn}, 
+                {PoiTable.Amenity}, 
+                {PoiTable.Latitude}, 
+                {PoiTable.Longitude})
             VALUES (@osm_id, @name, @amenity, @latitude, @longitude);
             """;
 
@@ -60,10 +65,18 @@ public sealed class SqlitePoiRepository : IPoiRepository
         await using var connection = _connectionFactory();
         await connection.OpenAsync(cancellationToken: ct);
 
-        const string sql = """
-            SELECT id, osm_id, name, amenity, latitude, longitude
-            FROM poi
-            ORDER BY id
+        const string sql = $"""
+            SELECT 
+                {PoiTable.Id}, 
+                {PoiTable.OsmId}, 
+                {PoiTable.NameColumn}, 
+                {PoiTable.Amenity}, 
+                {PoiTable.Latitude}, 
+                {PoiTable.Longitude}
+            FROM 
+                {PoiTable.Name}
+            ORDER BY 
+                {PoiTable.Id}
             LIMIT @limit;
             """;
 
@@ -91,9 +104,62 @@ public sealed class SqlitePoiRepository : IPoiRepository
         return result;
     }
 
-    public Task<IReadOnlyList<Poi>> GetByAmenityAsync(string amenity, int limit = 100, CancellationToken ct = default)
+    public async Task<IReadOnlyList<Poi>> GetByAmenityAsync(string amenity, int limit = 100, CancellationToken ct = default)
     {
-        throw new NotImplementedException();
+        if (string.IsNullOrWhiteSpace(amenity))
+        {
+            throw new ArgumentException("Amenity must be a non-empty string.", nameof(amenity));
+        }
+
+        if (limit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be greater than zero.");
+        }
+        var result = new List<Poi>();
+
+        await using var connection = _connectionFactory();
+        await connection.OpenAsync(cancellationToken: ct);
+
+        var sql = $"""
+            SELECT 
+                {PoiTable.Id}, 
+                {PoiTable.OsmId}, 
+                {PoiTable.NameColumn}, 
+                {PoiTable.Amenity}, 
+                {PoiTable.Latitude}, 
+                {PoiTable.Longitude}
+            FROM 
+                {PoiTable.Name}
+            WHERE
+                {PoiTable.Amenity} = @amenity
+            ORDER BY 
+                {PoiTable.Id}
+            LIMIT @limit;
+            """;
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("@amenity", amenity);
+        command.Parameters.AddWithValue("@limit", limit);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken: ct);
+
+        while (await reader.ReadAsync(cancellationToken: ct))
+        {
+            var poi = new Poi(
+                Id: reader.GetInt64(IdOrdinal),
+                OsmId: reader.GetInt64(OsmIdOrdinal),
+                Name: reader.IsDBNull(NameOrdinal) ? null : reader.GetString(NameOrdinal),
+                Amenity: reader.IsDBNull(AmenityOrdinal) ? null : reader.GetString(AmenityOrdinal),
+                Location: new GeoPoint(
+                    Latitude: reader.GetDouble(LatitudeOrdinal),
+                    Longitude: reader.GetDouble(LongitudeOrdinal))
+            );
+
+            result.Add(poi);
+        }
+
+        return result;
     }
 
     public Task<IReadOnlyList<Poi>> GetByLocationAsync(double latitude, double longitude, double radiusInMeters, int limit = 100, CancellationToken ct = default)

--- a/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
+++ b/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
@@ -90,4 +90,20 @@ public sealed class SqlitePoiRepository : IPoiRepository
 
         return result;
     }
+
+    public Task<IReadOnlyList<Poi>> GetByAmenityAsync(string amenity, int limit = 100, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IReadOnlyList<Poi>> GetByLocationAsync(double latitude, double longitude, double radiusInMeters, int limit = 100, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IReadOnlyList<Poi>> GetByNameAsync(string name, int limit = 100, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
 }

--- a/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
+++ b/src/POIneer.Render/Infrastructure/Sqlite/SqlitePoiRepository.cs
@@ -30,7 +30,7 @@ public sealed class SqlitePoiRepository : IPoiRepository
         await using var connection = _connectionFactory();
         await connection.OpenAsync(cancellationToken: ct);
 
-        const string sql = $"""
+        var sql = $"""
             INSERT INTO {PoiTable.Name} (
                 {PoiTable.OsmId}, 
                 {PoiTable.NameColumn}, 
@@ -65,7 +65,7 @@ public sealed class SqlitePoiRepository : IPoiRepository
         await using var connection = _connectionFactory();
         await connection.OpenAsync(cancellationToken: ct);
 
-        const string sql = $"""
+        var sql = $"""
             SELECT 
                 {PoiTable.Id}, 
                 {PoiTable.OsmId}, 
@@ -198,10 +198,26 @@ public sealed class SqlitePoiRepository : IPoiRepository
         int limit = 100,
         CancellationToken ct = default)
     {
+        if (boundingBox is null)
+        {
+            throw new ArgumentNullException(nameof(boundingBox));
+        }
+
         if (limit <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be greater than zero.");
         }
+
+        if (boundingBox.NorthWest.Latitude < boundingBox.SouthEast.Latitude)
+        {
+            throw new ArgumentException("NorthWest latitude must be greater than or equal to SouthEast latitude.");
+        }
+
+        if (boundingBox.NorthWest.Longitude > boundingBox.SouthEast.Longitude)
+        {
+            throw new ArgumentException("NorthWest longitude must be less than or equal to SouthEast longitude.");
+        }
+
 
         var result = new List<Poi>();
         await using var connection = _connectionFactory();

--- a/tests/POIneer.Render.IntegrationTests/Adapters/Output/SqliteExporterTests.cs
+++ b/tests/POIneer.Render.IntegrationTests/Adapters/Output/SqliteExporterTests.cs
@@ -43,7 +43,6 @@ public sealed class SqliteExporterTests(ITestOutputHelper output)
     {
         await using var tempDir = TestTemporaryDirectories.Create("sqlite-insert-multiple-pois", false);
 
-        var root = FindRepositoryRoot();
         var dbPath = Path.Combine(tempDir.DirectoryPath, "poi.sqlite");
 
         var options = Options.Create(new FlywayOptions
@@ -123,27 +122,6 @@ public sealed class SqliteExporterTests(ITestOutputHelper output)
             yield return poi;
             await Task.Yield();
         }
-    }
-
-    //TODO RepoRootLocator.Find() in main code and reuse here
-    private static string FindRepositoryRoot()
-    {
-        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
-
-        while (dir is not null)
-        {
-            var flywayConfigPath = Path.Combine(
-                dir.FullName,
-                "migrations",
-                "flyway-poi.toml");
-
-            if (File.Exists(flywayConfigPath))
-                return dir.FullName;
-
-            dir = dir.Parent;
-        }
-
-        throw new InvalidOperationException("Repository root could not be determined.");
     }
 
     private sealed class FakeHostEnvironment : IHostEnvironment

--- a/tests/POIneer.Render.IntegrationTests/Adapters/Output/SqliteExporterTests.cs
+++ b/tests/POIneer.Render.IntegrationTests/Adapters/Output/SqliteExporterTests.cs
@@ -43,24 +43,7 @@ public sealed class SqliteExporterTests(ITestOutputHelper output)
     {
         await using var tempDir = TestTemporaryDirectories.Create("sqlite-insert-multiple-pois", false);
 
-        var dbPath = Path.Combine(tempDir.DirectoryPath, "poi.sqlite");
-
-        var options = Options.Create(new FlywayOptions
-        {
-            Executable = "flyway",
-            ConfigFileRelativePath = "migrations/flyway-poi.toml",
-            Debug = false
-        });
-
-        var processRunner = new ProcessRunner();
-        var invocationBuilder = new FlywayInvocationBuilder(options);
-        var logger = new LoggerFactory().CreateLogger<FlywaySqliteDatabaseInitializer>();
-        var databaseInitializer = new FlywaySqliteDatabaseInitializer(
-            processRunner,
-            invocationBuilder,
-            logger);
-
-        await databaseInitializer.InitializeAsync(dbPath, CancellationToken.None);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
 
         Assert.True(File.Exists(dbPath));
         var tables = await GetTableNamesAsync(dbPath);

--- a/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByAmenityTests.cs
+++ b/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByAmenityTests.cs
@@ -1,4 +1,6 @@
+using POIneer.Render.Infrastructure.Sqlite;
 using POIneer.Render.TestHelpers;
+using POIneer.Render.TestHelpers.Sqlite;
 using Xunit;
 
 namespace POIneer.Render.IntegrationTests.Infrastructure.Sqlite.PoiRepository;
@@ -9,8 +11,8 @@ public sealed class SqlitePoiRepositoryGetByAmenityTests
     public async Task GetByAmenityAsync_ReturnsMatchingPois()
     {
         // Arrange
-        await using var tempDir = TestTemporaryDirectories.Create("GetByAmenityAsync_ReturnsMatchingPois", false);
-
+        await using var tempDir = TestTemporaryDirectories.Create("GetByAmenityAsync_ReturnsMatchingPois", true);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
 
         // Act
 

--- a/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByAmenityTests.cs
+++ b/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByAmenityTests.cs
@@ -97,6 +97,45 @@ public sealed class SqlitePoiRepositoryGetByAmenityTests
             await repository.GetByAmenityAsync("restaurant", limit, CancellationToken.None));
     }
 
+    [Fact]
+    public async Task GetByAmenityQuery_UsesAmenityIndex()
+    {
+        await using var tempDir =
+            TestTemporaryDirectories.Create("GetByAmenityQuery_UsesAmenityIndex");
+
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+
+        await using var connection =
+            new SqliteConnection(SqliteTestDatabase.CreateConnectionString(dbPath));
+
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+        EXPLAIN QUERY PLAN
+        SELECT id, osm_id, name, amenity, latitude, longitude
+        FROM poi
+        WHERE amenity = @amenity
+        ORDER BY id
+        LIMIT @limit;
+        """;
+
+        command.Parameters.AddWithValue("@amenity", "restaurant");
+        command.Parameters.AddWithValue("@limit", 10);
+
+        var details = new List<string>();
+
+        await using var reader = await command.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            details.Add(reader.GetString(3));
+        }
+
+        Assert.Contains(details, detail =>
+            detail.Contains("idx_poi_amenity", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static SqlitePoiRepository CreateSut(string dbPath) => new SqlitePoiRepository(() =>
     {
         var cs = SqliteTestDatabase.CreateConnectionString(dbPath);

--- a/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByAmenityTests.cs
+++ b/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByAmenityTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Data.Sqlite;
+using POIneer.Render.Domain.Models;
 using POIneer.Render.Infrastructure.Sqlite;
 using POIneer.Render.TestHelpers;
 using POIneer.Render.TestHelpers.Sqlite;
@@ -11,31 +13,104 @@ public sealed class SqlitePoiRepositoryGetByAmenityTests
     public async Task GetByAmenityAsync_ReturnsMatchingPois()
     {
         // Arrange
-        await using var tempDir = TestTemporaryDirectories.Create("GetByAmenityAsync_ReturnsMatchingPois", true);
+        await using var tempDir = TestTemporaryDirectories.Create("GetByAmenityAsync_ReturnsMatchingPois", false);
         var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
 
         // Act
+        var restaurants = await repository.GetByAmenityAsync("restaurant", 10, CancellationToken.None);
 
         // Assert
+        Assert.Equal(2, restaurants.Count);
+        Assert.All(restaurants, r => Assert.Equal("restaurant", r.Amenity));
+        Assert.Contains(restaurants, r => r.Name == "Pizza Napoli");
+        Assert.Contains(restaurants, r => r.Name == "Burger House");
+        Assert.DoesNotContain(restaurants, r => r.Name == "Cafe Berlin");
+
     }
 
     [Fact]
     public async Task GetByAmenityAsync_RespectsLimit()
     {
         // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByAmenityAsync_RespectsLimit", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
 
         // Act
+        var restaurants = await repository.GetByAmenityAsync("restaurant", 1, CancellationToken.None);
 
         // Assert
+        Assert.Single(restaurants);
+        Assert.Equal("restaurant", restaurants[0].Amenity);
+        Assert.True(restaurants[0].Name == "Pizza Napoli");
     }
 
     [Fact]
     public async Task GetByAmenityAsync_ReturnsEmptyList_WhenAmenityDoesNotExist()
     {
         // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByAmenityAsync_ReturnsEmptyList_WhenAmenityDoesNotExist", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
 
         // Act
+        var result = await repository.GetByAmenityAsync("nonexistent", 10, CancellationToken.None);
 
         // Assert
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task GetByAmenityAsync_Throws_WhenAmenityIsEmpty(string amenity)
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByAmenityAsync_Throws_WhenAmenityIsEmpty", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await repository.GetByAmenityAsync(amenity, 10, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task GetByAmenityAsync_Throws_WhenLimitIsInvalid(int limit)
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByAmenityAsync_Throws_WhenLimitIsInvalid", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await repository.GetByAmenityAsync("restaurant", limit, CancellationToken.None));
+    }
+
+    private static SqlitePoiRepository CreateSut(string dbPath) => new SqlitePoiRepository(() =>
+    {
+        var cs = SqliteTestDatabase.CreateConnectionString(dbPath);
+
+        return new SqliteConnection(cs);
+    });
+
+    private static Task SeedDefaultPoisAsync(SqlitePoiRepository repository)
+    {
+        return PoiSeedHelper.SeedAsync(
+            repository,
+            new Poi(1, 1001, "Pizza Napoli", "restaurant", new GeoPoint(52.5201, 13.4051)),
+            new Poi(3, 2001, "Cafe Berlin", "cafe", new GeoPoint(52.5202, 13.4052)),
+            new Poi(2, 1002, "Burger House", "restaurant", new GeoPoint(52.5203, 13.4053)),
+            new Poi(4, 3001, "Library Central", "library", new GeoPoint(52.5204, 13.4054)));
     }
 }

--- a/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByAmenityTests.cs
+++ b/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByAmenityTests.cs
@@ -1,0 +1,39 @@
+using POIneer.Render.TestHelpers;
+using Xunit;
+
+namespace POIneer.Render.IntegrationTests.Infrastructure.Sqlite.PoiRepository;
+
+public sealed class SqlitePoiRepositoryGetByAmenityTests
+{
+    [Fact]
+    public async Task GetByAmenityAsync_ReturnsMatchingPois()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByAmenityAsync_ReturnsMatchingPois", false);
+
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public async Task GetByAmenityAsync_RespectsLimit()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+
+    [Fact]
+    public async Task GetByAmenityAsync_ReturnsEmptyList_WhenAmenityDoesNotExist()
+    {
+        // Arrange
+
+        // Act
+
+        // Assert
+    }
+}

--- a/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByBoundingBox.cs
+++ b/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByBoundingBox.cs
@@ -1,0 +1,130 @@
+using Microsoft.Data.Sqlite;
+using POIneer.Render.Domain.Models;
+using POIneer.Render.Infrastructure.Sqlite;
+using POIneer.Render.TestHelpers;
+using POIneer.Render.TestHelpers.Sqlite;
+using Xunit;
+
+namespace POIneer.Render.IntegrationTests.Infrastructure.Sqlite.PoiRepository;
+
+public sealed class SqlitePoiRepositoryGetByBoundingBoxTests
+{
+    [Fact]
+    public async Task GetByBoundingBoxAsync_ReturnsPoisWithinBoundingBox()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByBoundingBoxAsync_ReturnsPoisWithinBoundingBox", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
+
+        // Define a bounding box that includes some of the seeded POIs
+        var northWest = new GeoPoint(52.5300, 13.3400);
+        var southEast = new GeoPoint(52.4800, 13.4100);
+
+        // Act
+        var boundingBox = new BoundingBox(northWest, southEast);
+        var pois = await repository.GetByBoundingBoxAsync(boundingBox, 10, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(5, pois.Count);
+        Assert.Contains(pois, p => p.Name == "Café Einstein Stammhaus");
+        Assert.Contains(pois, p => p.Name == "Stadtbibliothek Mitte");
+        Assert.Contains(pois, p => p.Name == "Café am Neuen See");
+        Assert.Contains(pois, p => p.Name == "Burgermeister Schöneberg");
+        Assert.Contains(pois, p => p.Name == "Mustafa's Gemüse Kebap");
+    }
+
+    [Fact]
+    public async Task GetByBoundingBoxAsync_ReturnsEmptyList_WhenNoPoisWithinBoundingBox()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByBoundingBoxAsync_ReturnsEmptyList_WhenNoPoisWithinBoundingBox", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
+
+        // Define a bounding box that does not include any of the seeded POIs
+        var northWest = new GeoPoint(52.6000, 13.2000);
+        var southEast = new GeoPoint(52.5900, 13.2100);
+
+        // Act
+        var boundingBox = new BoundingBox(northWest, southEast);
+        var pois = await repository.GetByBoundingBoxAsync(boundingBox, 10, CancellationToken.None);
+
+        // Assert
+        Assert.Empty(pois);
+    }
+
+    private static SqlitePoiRepository CreateSut(string dbPath) => new SqlitePoiRepository(() =>
+    {
+        var cs = SqliteTestDatabase.CreateConnectionString(dbPath);
+
+        return new SqliteConnection(cs);
+    });
+
+    private static Task SeedDefaultPoisAsync(SqlitePoiRepository repository)
+    {
+        return PoiSeedHelper.SeedAsync(
+            repository,
+            new Poi(
+                Id: 1,
+                OsmId: 1001,
+                Name: "Café Einstein Stammhaus",
+                Amenity: "cafe",
+                Location: new GeoPoint(
+                    Latitude: 52.5076,
+                    Longitude: 13.3509)),
+            new Poi(
+                Id: 2,
+                OsmId: 1002,
+                Name: "Burgermeister Schöneberg",
+                Amenity: "fast_food",
+                Location: new GeoPoint(
+                    Latitude: 52.4897,
+                    Longitude: 13.3538)),
+            new Poi(
+                Id: 3,
+                OsmId: 1003,
+                Name: "Stadtbibliothek Mitte",
+                Amenity: "library",
+                Location: new GeoPoint(
+                    Latitude: 52.5251,
+                    Longitude: 13.3888)),
+            new Poi(
+                Id: 4,
+                OsmId: 1004,
+                Name: "Mustafa's Gemüse Kebap",
+                Amenity: "fast_food",
+                Location: new GeoPoint(
+                    Latitude: 52.4938,
+                    Longitude: 13.3876)),
+            new Poi(
+                Id: 6,
+                OsmId: 1006,
+                Name: "Café am Wasserturm",
+                Amenity: "cafe",
+                Location: new GeoPoint(
+                    Latitude: 52.5308,
+                    Longitude: 13.2995)),
+            new Poi(
+                Id: 7,
+                OsmId: 1007,
+                Name: "Funkturm Restaurant",
+                Amenity: "restaurant",
+                Location: new GeoPoint(
+                    Latitude: 52.5079,
+                    Longitude: 13.2746)),
+            new Poi(
+                Id: 5,
+                OsmId: 1005,
+                Name: "Café am Neuen See",
+                Amenity: "cafe",
+                Location: new GeoPoint(
+                    Latitude: 52.5145,
+                    Longitude: 13.3501))
+        );
+    }
+}

--- a/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByNameTests.cs
+++ b/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByNameTests.cs
@@ -1,4 +1,8 @@
+using Microsoft.Data.Sqlite;
+using POIneer.Render.Domain.Models;
+using POIneer.Render.Infrastructure.Sqlite;
 using POIneer.Render.TestHelpers;
+using POIneer.Render.TestHelpers.Sqlite;
 using Xunit;
 
 namespace POIneer.Render.IntegrationTests.Infrastructure.Sqlite.PoiRepository;
@@ -10,5 +14,120 @@ public sealed class SqlitePoiRepositoryGetByNameTests
     {
         // Arrange
         await using var tempDir = TestTemporaryDirectories.Create("GetByNameAsync_ReturnsMatchingPois", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
+
+        // Act
+        var pois = await repository.GetByNameAsync("Cafe Berlin", 10, CancellationToken.None);
+
+        // Assert
+        Assert.Single(pois);
+        Assert.Equal("Cafe Berlin", pois[0].Name);
+        Assert.Equal("cafe", pois[0].Amenity);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_RespectsLimit()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByNameAsync_RespectsLimit", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
+
+        // Act
+        var pois = await repository.GetByNameAsync("Two Same Names", 1, CancellationToken.None);
+
+        // Assert
+        Assert.Single(pois);
+        Assert.Equal("Two Same Names", pois[0].Name);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ReturnsEmptyList_WhenNameDoesNotExist()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByNameAsync_ReturnsEmptyList_WhenNameDoesNotExist", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
+
+        // Act
+        var pois = await repository.GetByNameAsync("Nonexistent Name", 10, CancellationToken.None);
+
+        // Assert
+        Assert.Empty(pois);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ThrowsArgumentException_WhenNameIsNullOrEmpty()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByNameAsync_ThrowsArgumentException_WhenNameIsNullOrEmpty", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => repository.GetByNameAsync(null!, 10, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentException>(() => repository.GetByNameAsync(string.Empty, 10, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentException>(() => repository.GetByNameAsync("   ", 10, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task GetByNameAsync_ThrowsArgumentOutOfRangeException_WhenLimitIsNotPositive(int limit)
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByNameAsync_ThrowsArgumentOutOfRangeException_WhenLimitIsNotPositive", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => repository.GetByNameAsync("Cafe Berlin", limit, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_CanHandleMultiplePoisWithSameName()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByNameAsync_CanHandleMultiplePoisWithSameName", false);
+        var dbPath = await SqliteTestDatabase.CreateAsync(tempDir);
+        var repository = CreateSut(dbPath);
+
+        await SeedDefaultPoisAsync(repository);
+
+        // Act
+        var pois = await repository.GetByNameAsync("Two Same Names", 10, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, pois.Count);
+        Assert.All(pois, poi => Assert.Equal("Two Same Names", poi.Name));
+    }
+
+    private static SqlitePoiRepository CreateSut(string dbPath) => new SqlitePoiRepository(() =>
+    {
+        var cs = SqliteTestDatabase.CreateConnectionString(dbPath);
+
+        return new SqliteConnection(cs);
+    });
+
+    private static Task SeedDefaultPoisAsync(SqlitePoiRepository repository)
+    {
+        return PoiSeedHelper.SeedAsync(
+            repository,
+            new Poi(1, 1001, "Pizza Napoli", "restaurant", new GeoPoint(52.5201, 13.4051)),
+            new Poi(3, 2001, "Cafe Berlin", "cafe", new GeoPoint(52.5202, 13.4052)),
+            new Poi(2, 1002, "Two Same Names", "restaurant", new GeoPoint(52.5203, 13.4053)),
+            new Poi(4, 3001, "Library Central", "library", new GeoPoint(52.5204, 13.4054)),
+            new Poi(2, 4001, "Two Same Names", "museum", new GeoPoint(52.5205, 13.4055)));
     }
 }

--- a/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByNameTests.cs
+++ b/tests/POIneer.Render.IntegrationTests/Infrastructure/Sqlite/PoiRepository/SqlitePoiRepositoryGetByNameTests.cs
@@ -1,0 +1,14 @@
+using POIneer.Render.TestHelpers;
+using Xunit;
+
+namespace POIneer.Render.IntegrationTests.Infrastructure.Sqlite.PoiRepository;
+
+public sealed class SqlitePoiRepositoryGetByNameTests
+{
+    [Fact]
+    public async Task GetByNameAsync_ReturnsMatchingPois()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("GetByNameAsync_ReturnsMatchingPois", false);
+    }
+}

--- a/tests/POIneer.Render.IntegrationTests/POIneer.Render.IntegrationTests.csproj
+++ b/tests/POIneer.Render.IntegrationTests/POIneer.Render.IntegrationTests.csproj
@@ -35,6 +35,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="..\..\migrations\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>migrations\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\POIneer.Render\POIneer.Render.csproj" />
     <ProjectReference Include="..\POIneer.Render.TestHelpers\POIneer.Render.TestHelpers.csproj" />
   </ItemGroup>

--- a/tests/POIneer.Render.TestHelpers/Sqlite/PoiSeedHelper.cs
+++ b/tests/POIneer.Render.TestHelpers/Sqlite/PoiSeedHelper.cs
@@ -1,0 +1,17 @@
+using POIneer.Render.Domain;
+using POIneer.Render.Domain.Models;
+
+namespace POIneer.Render.TestHelpers.Sqlite;
+
+public static class PoiSeedHelper
+{
+    public static async Task SeedAsync(
+        IPoiRepository repository,
+        params Poi[] pois)
+    {
+        foreach (var poi in pois)
+        {
+            await repository.AddAsync(poi);
+        }
+    }
+}

--- a/tests/POIneer.Render.TestHelpers/Sqlite/TestDatabase.cs
+++ b/tests/POIneer.Render.TestHelpers/Sqlite/TestDatabase.cs
@@ -9,6 +9,7 @@ public static class SqliteTestDatabase
         return new SqliteConnectionStringBuilder
         {
             DataSource = dbPath,
+            // Important for tests to ensure that each connection is independent and doesn't interfere with others
             Pooling = false
         }.ToString();
     }

--- a/tests/POIneer.Render.TestHelpers/Sqlite/TestDatabase.cs
+++ b/tests/POIneer.Render.TestHelpers/Sqlite/TestDatabase.cs
@@ -1,4 +1,8 @@
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using POIneer.Render.Infrastructure.FileSystem;
+using POIneer.Render.Infrastructure.Flyway;
 
 namespace POIneer.Render.TestHelpers.Sqlite;
 
@@ -12,5 +16,40 @@ public static class SqliteTestDatabase
             // Important for tests to ensure that each connection is independent and doesn't interfere with others
             Pooling = false
         }.ToString();
+    }
+
+    public static async Task<string> CreateAsync(
+        TemporaryDirectory tempDir,
+        string fileName = "poi.sqlite",
+        CancellationToken ct = default)
+    {
+        var dbPath = Path.Combine(tempDir.DirectoryPath, fileName);
+
+        var options = Options.Create(new FlywayOptions
+        {
+            Executable = "flyway",
+            ConfigFileRelativePath = "migrations/flyway-poi.toml",
+            Debug = false
+        });
+
+        var processRunner = new ProcessRunner();
+
+        var invocationBuilder =
+            new FlywayInvocationBuilder(options);
+
+        using var loggerFactory = LoggerFactory.Create(builder => { });
+
+        var logger =
+            loggerFactory.CreateLogger<FlywaySqliteDatabaseInitializer>();
+
+        var initializer =
+            new FlywaySqliteDatabaseInitializer(
+                processRunner,
+                invocationBuilder,
+                logger);
+
+        await initializer.InitializeAsync(dbPath, ct);
+
+        return dbPath;
     }
 }


### PR DESCRIPTION
## Summary

Implemented basic POI query support for the MVP dataset.

This PR adds repository query methods for:

- filtering POIs by amenity
- filtering POIs by geographic bounding box

The goal is to make the generated SQLite dataset usable for future map rendering and exploration scenarios.

---

## Changes

### Repository methods

Added:

- `GetByAmenityAsync(...)`
- `GetByBoundingBoxAsync(...)`

### SQL query support

Implemented SQL queries for:

- amenity filtering
- geographic bounding box filtering

### Geographic model

Added:

- `BoundingBox`

using:

- `GeoPoint NorthWest`
- `GeoPoint SouthEast`

### Index usage

Queries are designed to use existing indexes:

- `idx_poi_amenity`
- `idx_poi_lat_lon`

Index usage was verified through query reasoning and SQLite query plan inspection.

### Tests

Added integration tests covering:

- amenity filtering
- bounding box filtering
- limits
- empty results
- invalid arguments

Tests run against real SQLite databases created via Flyway migrations.

---

## Out of scope

Not included in this PR:

- full-text search
- pagination
- advanced performance optimizations
- API/UI layer

---

## Acceptance Criteria

- [x] POIs can be filtered by amenity
- [x] POIs can be filtered by bounding box
- [x] Queries return correct results
- [x] Tests cover both query types
- [x] Queries use existing indexes

---

## Notes

The repository implementation intentionally keeps the query layer simple and explicit for the MVP:

- no generic query builder
- no ORM abstraction
- explicit SQL queries
- strongly typed domain models
- SQLite-focused implementation

This pull request adds new query capabilities to the POI repository, allowing for more flexible and efficient retrieval of POI data, and introduces supporting infrastructure and tests. The main changes include new repository methods for querying by amenity, name, and bounding box, the introduction of a `BoundingBox` model, and improvements to SQL query maintainability and test coverage.

**Repository and Query Enhancements:**

* Added new methods to `IPoiRepository` and implemented them in `SqlitePoiRepository` for querying POIs by amenity, name, and bounding box, each supporting a limit and cancellation token. [[1]](diffhunk://#diff-4cb006d8acd74dd5b407ce3a2728d4084a6f78c05bf7f0b36ee3ae9252b12c35R9-R22) [[2]](diffhunk://#diff-c3a2ca34f62a3a7a750e5e95c7712ad9ff71fa64fc530ab4ab18874925e2d458L78-R257)
* Introduced the `BoundingBox` record in the domain model to represent a rectangular geographic area for spatial queries.

**Infrastructure Improvements:**

* Centralized POI table and column names in the new `PoiTable` static class to reduce duplication and improve maintainability of SQL queries.
* Refactored SQL statements in `SqlitePoiRepository` to use constants from `PoiTable`, improving readability and maintainability. [[1]](diffhunk://#diff-c3a2ca34f62a3a7a750e5e95c7712ad9ff71fa64fc530ab4ab18874925e2d458L33-R39) [[2]](diffhunk://#diff-c3a2ca34f62a3a7a750e5e95c7712ad9ff71fa64fc530ab4ab18874925e2d458L63-R79)

**Testing and Test Infrastructure:**

* Added comprehensive integration tests for the new repository methods, including tests for correct filtering, limits, and error handling for amenity and bounding box queries. [[1]](diffhunk://#diff-608458373cee380a63e396ee752368f9550b588f990c23665fc50ec36e9c033dR1-R155) [[2]](diffhunk://#diff-2a2d3001c14a0f97eb52af016d7853637108c8b5a0192965c6ee937b96a7ae0fR1-R130)
* Refactored integration test setup to use a shared `SqliteTestDatabase` utility, simplifying database initialization and removing redundant code. [[1]](diffhunk://#diff-69ae7b6e845ab0e70ae976353f386bc9fd9c44f3306bc34076f881d6df25d430L46-R46) [[2]](diffhunk://#diff-69ae7b6e845ab0e70ae976353f386bc9fd9c44f3306bc34076f881d6df25d430L128-L148)