### PR TITLE
Feature/render region usecase

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,8 @@
         // You can optionally override config via command line:
         // "--Renderer:RegionsJson=config/regions.local.json"
         // "--Renderer:OnlyRegionId=berlin"
+        "--Renderer:OverwriteDatabase=true",
+        "--Renderer:OverwritePbf=false"
       ],
       "env": {
         // Host environment used by appsettings.{Environment}.json

--- a/src/POIneer.Render/Adapters/Input/FileDownloader.cs
+++ b/src/POIneer.Render/Adapters/Input/FileDownloader.cs
@@ -14,7 +14,11 @@ public sealed class HttpFileDownloader : IFileDownloader
         string targetPath,
         CancellationToken ct = default)
     {
-        Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+        var targetDirectory = Path.GetDirectoryName(targetPath);
+        if (!string.IsNullOrEmpty(targetDirectory))
+        {
+            Directory.CreateDirectory(targetDirectory);
+        }
 
         // Download with HttpClient and stream directly to file to avoid loading the entire file into memory
         using var response = await _httpClient.GetAsync(

--- a/src/POIneer.Render/Adapters/Input/FileDownloader.cs
+++ b/src/POIneer.Render/Adapters/Input/FileDownloader.cs
@@ -9,13 +9,27 @@ public sealed class HttpFileDownloader : IFileDownloader
     public HttpFileDownloader(HttpClient httpClient)
         => _httpClient = httpClient;
 
-    public async Task<string> DownloadAsync(string url, string targetPath, CancellationToken ct = default)
+    public async Task<string> DownloadAsync(
+        string url,
+        string targetPath,
+        CancellationToken ct = default)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
 
+        // Download with HttpClient and stream directly to file to avoid loading the entire file into memory
+        using var response = await _httpClient.GetAsync(
+            url,
+            HttpCompletionOption.ResponseHeadersRead,
+            ct);
+
+        response.EnsureSuccessStatusCode();
+
+        await using var httpStream =
+            await response.Content.ReadAsStreamAsync(ct);
+
         await using var fileStream = File.Create(targetPath);
-        await using var stream = await _httpClient.GetStreamAsync(url, ct);
-        await stream.CopyToAsync(fileStream, ct);
+
+        await httpStream.CopyToAsync(fileStream, ct);
 
         return targetPath;
     }

--- a/src/POIneer.Render/Adapters/Output/SqliteExporter.cs
+++ b/src/POIneer.Render/Adapters/Output/SqliteExporter.cs
@@ -1,5 +1,4 @@
 using Microsoft.Data.Sqlite;
-using POIneer.Render.Application.Contracts;
 using POIneer.Render.Domain.Models;
 using POIneer.Render.Ports;
 

--- a/src/POIneer.Render/Application/Options/RendererOptions.cs
+++ b/src/POIneer.Render/Application/Options/RendererOptions.cs
@@ -1,4 +1,4 @@
-namespace POIneer.Render.Cli;
+namespace POIneer.Render.Application.Options;
 
 // Strongly-typed configuration bound from appsettings/env/CLI
 public sealed class RendererOptions
@@ -8,10 +8,13 @@ public sealed class RendererOptions
     public required string OutDir { get; init; }
     public required string RegionsJson { get; init; }
 
+    public bool OverwriteDatabase { get; init; } = false;
+    public bool OverwritePbf { get; init; } = false;
+
     // If set, only this region will be rendered (e.g. for testing)
     public string? OnlyRegionId { get; init; }
 
-    public bool DryRun { get; init; }
+    public bool DryRun { get; init; } = false;
 
     public int DownloadTimeoutSeconds { get; init; } = 600;
 }

--- a/src/POIneer.Render/Application/Options/RendererOptionsValidation.cs
+++ b/src/POIneer.Render/Application/Options/RendererOptionsValidation.cs
@@ -1,0 +1,15 @@
+namespace POIneer.Render.Application.Options;
+
+public static class RendererOptionsValidation
+{
+    public const string RequiredPathsMessage = "WorkDir, OutDir, and RegionsJson must be set";
+    public const string DownloadTimeoutMessage = "DownloadTimeoutSeconds must be greater than 0";
+
+    public static bool HasRequiredPaths(RendererOptions options)
+        => !string.IsNullOrWhiteSpace(options.WorkDir)
+           && !string.IsNullOrWhiteSpace(options.OutDir)
+           && !string.IsNullOrWhiteSpace(options.RegionsJson);
+
+    public static bool HasValidDownloadTimeout(RendererOptions options)
+        => options.DownloadTimeoutSeconds > 0;
+}

--- a/src/POIneer.Render/Application/UseCases/RenderRegion.cs
+++ b/src/POIneer.Render/Application/UseCases/RenderRegion.cs
@@ -37,7 +37,8 @@ public sealed class RenderRegion : IRenderRegion
         string outDir,
         CancellationToken ct = default)
     {
-        var pbfPath = Path.Combine(workDir, $"{regionDto.Id}.osm.pbf");
+        var pbfPath = Path.Combine(workDir, regionDto.Id, "osm.pbf");
+
         if (!File.Exists(pbfPath))
             throw new FileNotFoundException($"PBF not found: {pbfPath}");
 

--- a/src/POIneer.Render/Application/UseCases/RenderRegion.cs
+++ b/src/POIneer.Render/Application/UseCases/RenderRegion.cs
@@ -1,10 +1,11 @@
 namespace POIneer.Render.Application.UseCases;
 
 using Microsoft.Extensions.Logging;
-using POIneer.Render.Ports;
 using POIneer.Render.Application.Contracts;
 using POIneer.Render.Application.Mapping;
+using POIneer.Render.Application.Options;
 using POIneer.Render.Domain.Models;
+using POIneer.Render.Ports;
 
 public sealed class RenderRegion : IRenderRegion
 {
@@ -14,6 +15,7 @@ public sealed class RenderRegion : IRenderRegion
     private readonly ISqliteDatabaseInitializer _dbInit;
     private readonly IExporter _exporter;
     private readonly IRawPoiMapper _rawPoiMapper;
+    private readonly RendererOptions _rendererOptions;
 
     public RenderRegion(
         ILogger<RenderRegion> log,
@@ -21,7 +23,8 @@ public sealed class RenderRegion : IRenderRegion
         ISqliteDatabaseInitializer dbInit,
         IOsmReader osmReader,
         IExporter exporter,
-        IRawPoiMapper rawPoiMapper)
+        IRawPoiMapper rawPoiMapper,
+        RendererOptions rendererOptions)
     {
         _logger = log;
         _polygonCutter = polygonCutter;
@@ -29,6 +32,7 @@ public sealed class RenderRegion : IRenderRegion
         _dbInit = dbInit;
         _exporter = exporter;
         _rawPoiMapper = rawPoiMapper;
+        _rendererOptions = rendererOptions;
     }
 
     public async Task RunAsync(
@@ -61,6 +65,15 @@ public sealed class RenderRegion : IRenderRegion
         Directory.CreateDirectory(regionOutDir);
 
         var outRegionPath = Path.Combine(regionOutDir, "poi.sqlite");
+        if (File.Exists(outRegionPath) && !_rendererOptions.OverwriteDatabase)
+        {
+            _logger.LogInformation("({Id}) Output SQLite already exists at {Out}, skipping rendering (overwrite disabled).", regionDto.Id, outRegionPath);
+            return;
+        }
+        else if (File.Exists(outRegionPath) && _rendererOptions.OverwriteDatabase)
+        {
+            _logger.LogInformation("({Id}) Output SQLite already exists at {Out}, but overwrite is enabled, re-rendering.", regionDto.Id, outRegionPath);
+        }
         var outputSqlitePathFull = Path.GetFullPath(outRegionPath);
 
         _logger.LogInformation("({Id}) Initializing SQLite database: {Out}", regionDto.Id, outputSqlitePathFull);

--- a/src/POIneer.Render/Application/UseCases/RenderRegion.cs
+++ b/src/POIneer.Render/Application/UseCases/RenderRegion.cs
@@ -1,6 +1,7 @@
 namespace POIneer.Render.Application.UseCases;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using POIneer.Render.Application.Contracts;
 using POIneer.Render.Application.Mapping;
 using POIneer.Render.Application.Options;
@@ -24,7 +25,7 @@ public sealed class RenderRegion : IRenderRegion
         IOsmReader osmReader,
         IExporter exporter,
         IRawPoiMapper rawPoiMapper,
-        RendererOptions rendererOptions)
+        IOptions<RendererOptions> options)
     {
         _logger = log;
         _polygonCutter = polygonCutter;
@@ -32,7 +33,7 @@ public sealed class RenderRegion : IRenderRegion
         _dbInit = dbInit;
         _exporter = exporter;
         _rawPoiMapper = rawPoiMapper;
-        _rendererOptions = rendererOptions;
+        _rendererOptions = options.Value;
     }
 
     public async Task RunAsync(
@@ -73,6 +74,7 @@ public sealed class RenderRegion : IRenderRegion
         else if (File.Exists(outRegionPath) && _rendererOptions.OverwriteDatabase)
         {
             _logger.LogInformation("({Id}) Output SQLite already exists at {Out}, but overwrite is enabled, re-rendering.", regionDto.Id, outRegionPath);
+            File.Delete(outRegionPath);
         }
         var outputSqlitePathFull = Path.GetFullPath(outRegionPath);
 

--- a/src/POIneer.Render/Application/UseCases/RenderRegion.cs
+++ b/src/POIneer.Render/Application/UseCases/RenderRegion.cs
@@ -43,7 +43,6 @@ public sealed class RenderRegion : IRenderRegion
         CancellationToken ct = default)
     {
         var pbfPath = Path.Combine(workDir, regionDto.Id, "osm.pbf");
-        //TODO: consider moving pbf downloading to a separate use case, to keep this one focused on the rendering logic
         var recreateDatabase = _rendererOptions.OverwriteDatabase || _rendererOptions.OverwritePbf;
 
         if (!File.Exists(pbfPath))

--- a/src/POIneer.Render/Application/UseCases/RenderRegion.cs
+++ b/src/POIneer.Render/Application/UseCases/RenderRegion.cs
@@ -43,6 +43,8 @@ public sealed class RenderRegion : IRenderRegion
         CancellationToken ct = default)
     {
         var pbfPath = Path.Combine(workDir, regionDto.Id, "osm.pbf");
+        //TODO: consider moving pbf downloading to a separate use case, to keep this one focused on the rendering logic
+        var recreateDatabase = _rendererOptions.OverwriteDatabase || _rendererOptions.OverwritePbf;
 
         if (!File.Exists(pbfPath))
             throw new FileNotFoundException($"PBF not found: {pbfPath}");
@@ -71,7 +73,7 @@ public sealed class RenderRegion : IRenderRegion
             _logger.LogInformation("({Id}) Output SQLite already exists at {Out}, skipping rendering (overwrite disabled).", regionDto.Id, outRegionPath);
             return;
         }
-        else if (File.Exists(outRegionPath) && _rendererOptions.OverwriteDatabase)
+        else if (File.Exists(outRegionPath) && recreateDatabase)
         {
             _logger.LogInformation("({Id}) Output SQLite already exists at {Out}, but overwrite is enabled, re-rendering.", regionDto.Id, outRegionPath);
             File.Delete(outRegionPath);

--- a/src/POIneer.Render/Application/UseCases/RenderRegion.cs
+++ b/src/POIneer.Render/Application/UseCases/RenderRegion.cs
@@ -67,7 +67,7 @@ public sealed class RenderRegion : IRenderRegion
         Directory.CreateDirectory(regionOutDir);
 
         var outRegionPath = Path.Combine(regionOutDir, "poi.sqlite");
-        if (File.Exists(outRegionPath) && !_rendererOptions.OverwriteDatabase)
+        if (File.Exists(outRegionPath) && !recreateDatabase)
         {
             _logger.LogInformation("({Id}) Output SQLite already exists at {Out}, skipping rendering (overwrite disabled).", regionDto.Id, outRegionPath);
             return;

--- a/src/POIneer.Render/Cli/Program.cs
+++ b/src/POIneer.Render/Cli/Program.cs
@@ -20,20 +20,20 @@ internal class Program
     private static async Task<int> Main(string[] args)
     {
         var builder = Host.CreateApplicationBuilder(args);
-        var sectionRenderer = builder.Configuration.GetSection("Renderer");
-        var bindSource = sectionRenderer.Exists() ? (IConfiguration)sectionRenderer : builder.Configuration;
 
-        // Load configuration with sane defaults and environment overlays
         builder.Configuration
             .SetBasePath(builder.Environment.ContentRootPath)
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
             .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
-            // Environment variables like: POINEER_RENDER__RENDERER__WORKDIR or POINEER_RENDER__WORKDIR (see binding below)
             .AddEnvironmentVariables(prefix: "POINEER_RENDER__")
             .AddCommandLine(args);
 
-        // Bind Options
-        // Prefer "Renderer" section; if not present, bind from root (fallback to keep compatibility)
+        var rendererSection = builder.Configuration.GetSection("Renderer");
+
+        IConfiguration bindSource = rendererSection.Exists()
+            ? rendererSection
+            : builder.Configuration;
+
         builder.Services
             .AddOptions<RendererOptions>()
             .Bind(bindSource)
@@ -41,26 +41,19 @@ internal class Program
                 !string.IsNullOrWhiteSpace(o.WorkDir) &&
                 !string.IsNullOrWhiteSpace(o.OutDir) &&
                 !string.IsNullOrWhiteSpace(o.RegionsJson),
-                "WorkDir, OutDir, and RegionsJson must be set");
+                "WorkDir, OutDir, and RegionsJson must be set")
+            .ValidateOnStart();
 
-        // Flyway options are bound in FlywayInvocationBuilder, 
-        // but we can also bind them here to have them available for other services if needed
         builder.Services
             .AddOptions<FlywayOptions>()
             .Bind(builder.Configuration.GetSection(FlywayOptions.SectionName));
 
-        // Flyway options
-        builder.Services.Configure<FlywayOptions>(
-            builder.Configuration.GetSection(FlywayOptions.SectionName));
-
-        // Wire ports/adapters + use cases
         builder.Services.AddHttpClient<IFileDownloader, HttpFileDownloader>((sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<RendererOptions>>().Value;
-
             client.Timeout = TimeSpan.FromSeconds(options.DownloadTimeoutSeconds);
         });
-        builder.Services.AddSingleton<IFileDownloader, HttpFileDownloader>();
+
         builder.Logging.ClearProviders();
         builder.Logging.AddSimpleConsole(options =>
         {

--- a/src/POIneer.Render/Cli/Program.cs
+++ b/src/POIneer.Render/Cli/Program.cs
@@ -6,8 +6,8 @@ using Microsoft.Extensions.Options;
 using POIneer.Render.Adapters.Input;
 using POIneer.Render.Adapters.Output;
 using POIneer.Render.Application.Mapping;
+using POIneer.Render.Application.Options;
 using POIneer.Render.Application.UseCases;
-using POIneer.Render.Cli;
 using POIneer.Render.Infrastructure.Adapters.Osm;
 using POIneer.Render.Infrastructure.FileSystem;
 using POIneer.Render.Infrastructure.Flyway;
@@ -31,8 +31,6 @@ internal class Program
             // Environment variables like: POINEER_RENDER__RENDERER__WORKDIR or POINEER_RENDER__WORKDIR (see binding below)
             .AddEnvironmentVariables(prefix: "POINEER_RENDER__")
             .AddCommandLine(args);
-
-
 
         // Bind Options
         // Prefer "Renderer" section; if not present, bind from root (fallback to keep compatibility)

--- a/src/POIneer.Render/Cli/Program.cs
+++ b/src/POIneer.Render/Cli/Program.cs
@@ -37,11 +37,8 @@ internal class Program
         builder.Services
             .AddOptions<RendererOptions>()
             .Bind(bindSource)
-            .Validate(o =>
-                !string.IsNullOrWhiteSpace(o.WorkDir) &&
-                !string.IsNullOrWhiteSpace(o.OutDir) &&
-                !string.IsNullOrWhiteSpace(o.RegionsJson),
-                "WorkDir, OutDir, and RegionsJson must be set")
+            .Validate(RendererOptionsValidation.HasRequiredPaths, RendererOptionsValidation.RequiredPathsMessage)
+            .Validate(RendererOptionsValidation.HasValidDownloadTimeout, RendererOptionsValidation.DownloadTimeoutMessage)
             .ValidateOnStart();
 
         builder.Services

--- a/src/POIneer.Render/Cli/Program.cs
+++ b/src/POIneer.Render/Cli/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using POIneer.Render.Adapters.Input;
 using POIneer.Render.Adapters.Output;
 using POIneer.Render.Application.Mapping;
@@ -55,7 +56,12 @@ internal class Program
             builder.Configuration.GetSection(FlywayOptions.SectionName));
 
         // Wire ports/adapters + use cases
-        builder.Services.AddHttpClient(); // oder AddHttpClient<HttpFileDownloader>()
+        builder.Services.AddHttpClient<IFileDownloader, HttpFileDownloader>((sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<RendererOptions>>().Value;
+
+            client.Timeout = TimeSpan.FromSeconds(options.DownloadTimeoutSeconds);
+        });
         builder.Services.AddSingleton<IFileDownloader, HttpFileDownloader>();
         builder.Logging.ClearProviders();
         builder.Logging.AddSimpleConsole(options =>

--- a/src/POIneer.Render/Cli/RendererOptions.cs
+++ b/src/POIneer.Render/Cli/RendererOptions.cs
@@ -12,4 +12,6 @@ public sealed class RendererOptions
     public string? OnlyRegionId { get; init; }
 
     public bool DryRun { get; init; }
+
+    public int DownloadTimeoutSeconds { get; init; } = 600;
 }

--- a/src/POIneer.Render/Cli/Runner.cs
+++ b/src/POIneer.Render/Cli/Runner.cs
@@ -33,6 +33,7 @@ public sealed class Runner
     public async Task<int> RunAsync(CancellationToken ct)
     {
         var contentRoot = _hostEnvironment.ContentRootPath;
+        var redownloadPbf = _rendererOptions.OverwritePbf;
 
         string Resolve(string p) => Path.IsPathRooted(p) ? p : Path.GetFullPath(Path.Combine(contentRoot, p));
 
@@ -82,7 +83,7 @@ public sealed class Runner
                     _logger.LogInformation("Downloading PBF for {Region} ... to {TargetPath}", r.Id, pbfPath);
                     await _fileDownloader.DownloadAsync(r.PbfUrl, pbfPath, ct);
                 }
-                else if (!_rendererOptions.OverwritePbf)
+                else if (!redownloadPbf)
                 {
                     _logger.LogInformation("PBF already exists for {Region} at {TargetPath}, skipping download (overwrite disabled).", r.Id, pbfPath);
                 }

--- a/src/POIneer.Render/Cli/Runner.cs
+++ b/src/POIneer.Render/Cli/Runner.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using POIneer.Render.Cli;
+using POIneer.Render.Application.Options;
 using POIneer.Render.Ports;
 
 public sealed class Runner
@@ -80,6 +80,15 @@ public sealed class Runner
                 if (!File.Exists(pbfPath))
                 {
                     _logger.LogInformation("Downloading PBF for {Region} ... to {TargetPath}", r.Id, pbfPath);
+                    await _fileDownloader.DownloadAsync(r.PbfUrl, pbfPath, ct);
+                }
+                else if (!_rendererOptions.OverwritePbf)
+                {
+                    _logger.LogInformation("PBF already exists for {Region} at {TargetPath}, skipping download (overwrite disabled).", r.Id, pbfPath);
+                }
+                else
+                {
+                    _logger.LogInformation("PBF already exists for {Region} at {TargetPath}, but overwrite is enabled, re-downloading.", r.Id, pbfPath);
                     await _fileDownloader.DownloadAsync(r.PbfUrl, pbfPath, ct);
                 }
                 await _renderRegionUseCase.RunAsync(r, workDir, outDir, ct);

--- a/src/POIneer.Render/Cli/Runner.cs
+++ b/src/POIneer.Render/Cli/Runner.cs
@@ -60,7 +60,7 @@ public sealed class Runner
         Directory.CreateDirectory(workDir);
         Directory.CreateDirectory(outDir);
 
-        _logger.LogInformation("Directories created: {WorkDir}, {OutDir}", workDir, outDir);
+        _logger.LogInformation("Directories created (if not exists): {WorkDir}, {OutDir}", workDir, outDir);
 
         _logger.LogInformation("Using regions file: {RegionsPath}", regionsPath);
 
@@ -73,7 +73,10 @@ public sealed class Runner
         {
             using (_logger.BeginScope("region:{RegionId}", r.Id))
             {
-                var pbfPath = Path.Combine(workDir, $"{r.Id}.osm.pbf");
+                var regionWorkDir = Path.Combine(workDir, r.Id);
+                Directory.CreateDirectory(regionWorkDir);
+                var pbfPath = Path.Combine(regionWorkDir, "osm.pbf");
+
                 if (!File.Exists(pbfPath))
                 {
                     _logger.LogInformation("Downloading PBF for {Region} ... to {TargetPath}", r.Id, pbfPath);

--- a/src/POIneer.Render/Cli/config/regions.local.json
+++ b/src/POIneer.Render/Cli/config/regions.local.json
@@ -5,5 +5,12 @@
     "Country": "Germany",
     "Category": "City",
     "PbfUrl": "https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf"
+  },
+  {
+    "Id": "mittelfranken",
+    "Name": "Mittelfranken",
+    "Country": "Germany",
+    "Category": "District",
+    "PbfUrl": "https://download.geofabrik.de/europe/germany/bayern/mittelfranken-latest.osm.pbf"
   }
 ]

--- a/src/POIneer.Render/appsettings.Development.json
+++ b/src/POIneer.Render/appsettings.Development.json
@@ -3,7 +3,7 @@
     "WorkDir": "data/dev/renderer-work-dir",
     "OutDir": "data/dev/renderer-out-dir",
     "RegionsJson": "Cli/config/regions.local.json",
-    "OnlyRegionId": "berlin"
+    "OnlyRegionId": null
   },
   "Flyway": {
     "Executable": "flyway",

--- a/tests/POIneer.Render.TestHelpers/TestFiles.cs
+++ b/tests/POIneer.Render.TestHelpers/TestFiles.cs
@@ -4,8 +4,11 @@ public static class TestFiles
         string path,
         string content)
     {
-        Directory.CreateDirectory(
-            Path.GetDirectoryName(path)!);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
 
         File.WriteAllText(path, content);
     }

--- a/tests/POIneer.Render.TestHelpers/TestFiles.cs
+++ b/tests/POIneer.Render.TestHelpers/TestFiles.cs
@@ -1,0 +1,12 @@
+public static class TestFiles
+{
+    public static void WriteAllText(
+        string path,
+        string content)
+    {
+        Directory.CreateDirectory(
+            Path.GetDirectoryName(path)!);
+
+        File.WriteAllText(path, content);
+    }
+}

--- a/tests/POIneer.Render.TestHelpers/TestRendererOptions.cs
+++ b/tests/POIneer.Render.TestHelpers/TestRendererOptions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Options;
+using POIneer.Render.Application.Options;
+
+public static class TestRendererOptions
+{
+    public static IOptions<RendererOptions> Create(
+        bool overwriteDatabase = false,
+        bool overwritePbf = false)
+        => Options.Create(new RendererOptions
+        {
+            WorkDir = "test-work-dir",
+            OutDir = "test-out-dir",
+            RegionsJson = "test-regions.json",
+            OverwriteDatabase = overwriteDatabase,
+            OverwritePbf = overwritePbf,
+            DownloadTimeoutSeconds = 600
+        });
+}

--- a/tests/POIneer.Render.UnitTests/Application/Options/RendererOptionsValidationTests.cs
+++ b/tests/POIneer.Render.UnitTests/Application/Options/RendererOptionsValidationTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using POIneer.Render.Application.Options;
 using Xunit;
 
@@ -23,7 +24,7 @@ public sealed class RendererOptionsValidationTests
         var result = RendererOptionsValidation.HasValidDownloadTimeout(options);
 
         // Assert
-        Assert.False(result);
+        result.Should().BeFalse();
     }
 
     [Fact]
@@ -42,6 +43,6 @@ public sealed class RendererOptionsValidationTests
         var result = RendererOptionsValidation.HasValidDownloadTimeout(options);
 
         // Assert
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 }

--- a/tests/POIneer.Render.UnitTests/Application/Options/RendererOptionsValidationTests.cs
+++ b/tests/POIneer.Render.UnitTests/Application/Options/RendererOptionsValidationTests.cs
@@ -1,0 +1,47 @@
+using POIneer.Render.Application.Options;
+using Xunit;
+
+namespace POIneer.Render.UnitTests.Application.Options;
+
+public sealed class RendererOptionsValidationTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void HasValidDownloadTimeout_ReturnsFalse_WhenTimeoutIsNotPositive(int timeoutSeconds)
+    {
+        // Arrange
+        var options = new RendererOptions
+        {
+            WorkDir = "work",
+            OutDir = "out",
+            RegionsJson = "regions.json",
+            DownloadTimeoutSeconds = timeoutSeconds
+        };
+
+        // Act
+        var result = RendererOptionsValidation.HasValidDownloadTimeout(options);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasValidDownloadTimeout_ReturnsTrue_WhenTimeoutIsPositive()
+    {
+        // Arrange
+        var options = new RendererOptions
+        {
+            WorkDir = "work",
+            OutDir = "out",
+            RegionsJson = "regions.json",
+            DownloadTimeoutSeconds = 1
+        };
+
+        // Act
+        var result = RendererOptionsValidation.HasValidDownloadTimeout(options);
+
+        // Assert
+        Assert.True(result);
+    }
+}

--- a/tests/POIneer.Render.UnitTests/Application/UseCases/RenderRegions/RenderRegionTests.cs
+++ b/tests/POIneer.Render.UnitTests/Application/UseCases/RenderRegions/RenderRegionTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using POIneer.Render.Application.Contracts;
 using POIneer.Render.Application.Mapping;
+using POIneer.Render.Application.Options;
 using POIneer.Render.Application.Ports.Model;
 using POIneer.Render.Application.UseCases;
 using POIneer.Render.Domain.Models;
@@ -21,14 +23,22 @@ public sealed class RenderRegionTests
     private readonly ISqliteDatabaseInitializer _dbInit = Substitute.For<ISqliteDatabaseInitializer>();
     private readonly IExporter _exporter = Substitute.For<IExporter>();
 
-    private RenderRegion CreateSut()
-        => new(
-            _logger,
-            _polygonCutter,
-            _dbInit,
-            _osmReader,
-            _exporter,
-            Substitute.For<IRawPoiMapper>());
+
+    private RenderRegion CreateSut(
+       ILogger<RenderRegion>? logger = null,
+       IPolygonCutter? polygonCutter = null,
+       ISqliteDatabaseInitializer? dbInit = null,
+       IOsmReader? osmReader = null,
+       IExporter? exporter = null,
+       IRawPoiMapper? mapper = null)
+       => new(
+           logger ?? _logger,
+           polygonCutter ?? _polygonCutter,
+           dbInit ?? _dbInit,
+           osmReader ?? _osmReader,
+           exporter ?? _exporter,
+           mapper ?? Substitute.For<IRawPoiMapper>(),
+           TestRendererOptions.Create().Value);
 
     [Fact]
     public async Task RunAsync_ThrowsFileNotFoundException_WhenPbfDoesNotExist()
@@ -78,10 +88,11 @@ public sealed class RenderRegionTests
         var outDir = tempDir.CreateSubDir("out").DirectoryPath;
 
         // create input pbf file
-        var pbfPath = Path.Combine(workDir, $"{region.Id}.osm.pbf");
-        File.WriteAllText(pbfPath, "dummy");
+        var pbfPath = Path.Combine(workDir, region.Id, "osm.pbf");
 
-        var cutPbfPath = Path.Combine(workDir, $"{region.Id}.cut.osm.pbf");
+        TestFiles.WriteAllText(pbfPath, "dummy");
+
+        var cutPbfPath = Path.Combine(workDir, region.Id, $"cut.osm.pbf");
         _polygonCutter
             .CutAsync(pbfPath, region.Poly, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(cutPbfPath));
@@ -134,10 +145,11 @@ public sealed class RenderRegionTests
         var workDir = tempDir.CreateSubDir("work").DirectoryPath;
         var outDir = tempDir.CreateSubDir("out").DirectoryPath;
 
-        var pbfPath = Path.Combine(workDir, $"{region.Id}.osm.pbf");
-        File.WriteAllText(pbfPath, "dummy");
+        var pbfPath = Path.Combine(workDir, region.Id, "osm.pbf");
 
-        var cutPbfPath = Path.Combine(workDir, $"{region.Id}.cut.osm.pbf");
+        TestFiles.WriteAllText(pbfPath, "dummy");
+
+        var cutPbfPath = Path.Combine(workDir, region.Id, "cut.osm.pbf");
 
         using var cts = new CancellationTokenSource();
         var ct = cts.Token;
@@ -171,13 +183,12 @@ public sealed class RenderRegionTests
         var initDb = Substitute.For<ISqliteDatabaseInitializer>();
         var exporter = Substitute.For<IExporter>();
 
-        var sut = new RenderRegion(
-            logger,
-            polygonCutter,
-            initDb,
-            osmReader,
-            exporter,
-            Substitute.For<IRawPoiMapper>());
+        var sut = CreateSut(
+            logger: logger,
+            polygonCutter: polygonCutter,
+            dbInit: initDb,
+            osmReader: osmReader,
+            exporter: exporter);
 
         var region = new RegionDto(
             Id: "berlin",
@@ -190,11 +201,11 @@ public sealed class RenderRegionTests
         var outDir = tempDir.CreateSubDir("out").DirectoryPath;
 
         // Dummy input PBF (existence is what matters)
-        var pbfPath = Path.Combine(workDir, $"{region.Id}.osm.pbf");
-        File.WriteAllText(pbfPath, "dummy");
+        var pbfPath = Path.Combine(workDir, region.Id, "osm.pbf");
+        TestFiles.WriteAllText(pbfPath, "dummy");
 
         // Cut result
-        var cutPbfPath = Path.Combine(workDir, $"{region.Id}.cut.osm.pbf");
+        var cutPbfPath = Path.Combine(workDir, region.Id, "cut.osm.pbf");
         polygonCutter
             .CutAsync(pbfPath, region.Poly, Arg.Any<CancellationToken>())
             .Returns(cutPbfPath);
@@ -226,14 +237,21 @@ public sealed class RenderRegionTests
         await sut.RunAsync(region, workDir, outDir, CancellationToken.None);
 
         // Assert
-        var expectedOutPath = Path.Combine(outDir, $"{region.Id}.sqlite");
+        var expectedOutPath = Path.Combine(outDir, region.Id, "poi.sqlite");
+
+        await exporter.Received(1).ExportAsync(
+            Arg.Any<IAsyncEnumerable<Poi>>(),
+            expectedOutPath,
+            Arg.Any<CancellationToken>());
 
         Received.InOrder(() =>
         {
             polygonCutter.CutAsync(pbfPath, region.Poly, Arg.Any<CancellationToken>());
             osmReader.ReadAmenityNodesAsync(cutPbfPath, Arg.Any<CancellationToken>());
-            //TODO: reenble when exporter is enabled
-            //exporter.ExportAsync(pois, expectedOutPath, Arg.Any<CancellationToken>());
+            exporter.ExportAsync(
+                Arg.Any<IAsyncEnumerable<Poi>>(),
+                expectedOutPath,
+                Arg.Any<CancellationToken>());
         });
     }
 }

--- a/tests/POIneer.Render.UnitTests/Application/UseCases/RenderRegions/RenderRegionTests.cs
+++ b/tests/POIneer.Render.UnitTests/Application/UseCases/RenderRegions/RenderRegionTests.cs
@@ -25,20 +25,22 @@ public sealed class RenderRegionTests
 
 
     private RenderRegion CreateSut(
-       ILogger<RenderRegion>? logger = null,
-       IPolygonCutter? polygonCutter = null,
-       ISqliteDatabaseInitializer? dbInit = null,
-       IOsmReader? osmReader = null,
-       IExporter? exporter = null,
-       IRawPoiMapper? mapper = null)
-       => new(
-           logger ?? _logger,
-           polygonCutter ?? _polygonCutter,
-           dbInit ?? _dbInit,
-           osmReader ?? _osmReader,
-           exporter ?? _exporter,
-           mapper ?? Substitute.For<IRawPoiMapper>(),
-           TestRendererOptions.Create());
+        ILogger<RenderRegion>? logger = null,
+        IPolygonCutter? polygonCutter = null,
+        ISqliteDatabaseInitializer? dbInit = null,
+        IOsmReader? osmReader = null,
+        IExporter? exporter = null,
+        IRawPoiMapper? mapper = null,
+        bool overwriteDatabase = false,
+        bool overwritePbf = false)
+        => new(
+            logger ?? _logger,
+            polygonCutter ?? _polygonCutter,
+            dbInit ?? _dbInit,
+            osmReader ?? _osmReader,
+            exporter ?? _exporter,
+            mapper ?? Substitute.For<IRawPoiMapper>(),
+            TestRendererOptions.Create(overwriteDatabase, overwritePbf));
 
     [Fact]
     public async Task RunAsync_ThrowsFileNotFoundException_WhenPbfDoesNotExist()
@@ -254,5 +256,47 @@ public sealed class RenderRegionTests
                 Arg.Any<CancellationToken>());
         });
     }
-}
 
+    [Fact]
+    public async Task RunAsync_RecreatesDatabase_WhenOutputExistsAndOverwritePbfIsEnabled()
+    {
+        // Arrange
+        var sut = CreateSut(overwritePbf: true);
+
+        var region = new RegionDto(
+            Id: "berlin",
+            Name: "Berlin",
+            PbfUrl: "http://example.com/berlin.osm.pbf",
+            Poly: "berlin.poly");
+
+        await using var tempDir = TestTemporaryDirectories.Create("recreate-db-when-overwrite-pbf-is-enabled", false);
+        var workDir = tempDir.CreateSubDir("work").DirectoryPath;
+        var outDir = tempDir.CreateSubDir("out").DirectoryPath;
+
+        var pbfPath = Path.Combine(workDir, region.Id, "osm.pbf");
+        TestFiles.WriteAllText(pbfPath, "dummy");
+
+        var existingOutputPath = Path.Combine(outDir, region.Id, "poi.sqlite");
+        TestFiles.WriteAllText(existingOutputPath, "existing");
+
+        var cutPbfPath = Path.Combine(workDir, region.Id, "cut.osm.pbf");
+        _polygonCutter
+            .CutAsync(pbfPath, region.Poly, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(cutPbfPath));
+
+        _osmReader
+            .ReadAmenityNodesAsync(cutPbfPath, Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerable.Empty<RawPoi>());
+
+        // Act
+        await sut.RunAsync(region, workDir, outDir, CancellationToken.None);
+
+        // Assert
+        await _dbInit.Received(1).InitializeAsync(existingOutputPath, Arg.Any<CancellationToken>());
+        await _exporter.Received(1).ExportAsync(
+            Arg.Any<IAsyncEnumerable<Poi>>(),
+            existingOutputPath,
+            Arg.Any<CancellationToken>());
+        Assert.False(File.Exists(existingOutputPath));
+    }
+}

--- a/tests/POIneer.Render.UnitTests/Application/UseCases/RenderRegions/RenderRegionTests.cs
+++ b/tests/POIneer.Render.UnitTests/Application/UseCases/RenderRegions/RenderRegionTests.cs
@@ -38,7 +38,7 @@ public sealed class RenderRegionTests
            osmReader ?? _osmReader,
            exporter ?? _exporter,
            mapper ?? Substitute.For<IRawPoiMapper>(),
-           TestRendererOptions.Create().Value);
+           TestRendererOptions.Create());
 
     [Fact]
     public async Task RunAsync_ThrowsFileNotFoundException_WhenPbfDoesNotExist()

--- a/tests/POIneer.Render.UnitTests/Cli/RunnerTests.cs
+++ b/tests/POIneer.Render.UnitTests/Cli/RunnerTests.cs
@@ -1,0 +1,268 @@
+using FluentAssertions;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using POIneer.Render.Application.Contracts;
+using POIneer.Render.Application.Options;
+using POIneer.Render.Ports;
+using POIneer.Render.TestHelpers;
+using Xunit;
+
+namespace POIneer.Render.UnitTests.Cli;
+
+public sealed class RunnerTests
+{
+    private readonly IFileDownloader _fileDownloader = Substitute.For<IFileDownloader>();
+    private readonly IRegionSource _regionSource = Substitute.For<IRegionSource>();
+    private readonly IRenderRegion _renderRegion = Substitute.For<IRenderRegion>();
+
+    [Fact]
+    public async Task RunAsync_ReturnsSuccessAndDoesNothing_WhenDryRunIsEnabled()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("runner-dry-run", false);
+        var sut = CreateSut(tempDir.DirectoryPath, CreateOptions(dryRun: true));
+
+        // Act
+        var result = await sut.RunAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().Be(0);
+        await _regionSource.DidNotReceiveWithAnyArgs().GetRegionsAsync(default!, default);
+        await _fileDownloader.DidNotReceiveWithAnyArgs().DownloadAsync(default!, default!, default);
+        await _renderRegion.DidNotReceiveWithAnyArgs().RunAsync(default!, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task RunAsync_ThrowsFileNotFoundException_WhenRegionsFileDoesNotExist()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("runner-missing-regions", false);
+        var options = CreateOptions(regionsJson: "missing-regions.json");
+        var expectedRegionsPath = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.RegionsJson));
+        var sut = CreateSut(tempDir.DirectoryPath, options);
+
+        // Act
+        var act = () => sut.RunAsync(CancellationToken.None);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<FileNotFoundException>(act);
+        ex.Message.Should().Contain(expectedRegionsPath);
+
+        await _regionSource.DidNotReceiveWithAnyArgs().GetRegionsAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task RunAsync_ResolvesRelativePathsAgainstContentRoot_AndProcessesRegion()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("runner-resolves-relative-paths", false);
+        var options = CreateOptions(
+            workDir: "work",
+            outDir: "out",
+            regionsJson: "config/regions.json");
+        var sut = CreateSut(tempDir.DirectoryPath, options);
+
+        var regionsPath = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.RegionsJson));
+        TestFiles.WriteAllText(regionsPath, "[]");
+
+        var region = BerlinRegion();
+        _regionSource
+            .GetRegionsAsync(regionsPath, Arg.Any<CancellationToken>())
+            .Returns(new[] { region });
+
+        var workDir = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.WorkDir));
+        var outDir = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.OutDir));
+        var expectedPbfPath = Path.Combine(workDir, region.Id, "osm.pbf");
+
+        // Act
+        var result = await sut.RunAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().Be(0);
+        await _fileDownloader.Received(1).DownloadAsync(region.PbfUrl, expectedPbfPath, Arg.Any<CancellationToken>());
+        await _renderRegion.Received(1).RunAsync(region, workDir, outDir, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_SkipsDownload_WhenPbfAlreadyExistsAndOverwritePbfIsDisabled()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("runner-skip-existing-pbf", false);
+        var options = CreateOptions(overwritePbf: false);
+        var sut = CreateSut(tempDir.DirectoryPath, options);
+
+        var regionsPath = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.RegionsJson));
+        TestFiles.WriteAllText(regionsPath, "[]");
+
+        var region = BerlinRegion();
+        _regionSource.GetRegionsAsync(regionsPath, Arg.Any<CancellationToken>())
+            .Returns(new[] { region });
+
+        var workDir = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.WorkDir));
+        var pbfPath = Path.Combine(workDir, region.Id, "osm.pbf");
+        TestFiles.WriteAllText(pbfPath, "existing pbf");
+
+        // Act
+        await sut.RunAsync(CancellationToken.None);
+
+        // Assert
+        await _fileDownloader.DidNotReceiveWithAnyArgs().DownloadAsync(default!, default!, default);
+        await _renderRegion.Received(1).RunAsync(
+            region,
+            workDir,
+            Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.OutDir)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_RedownloadsPbf_WhenPbfAlreadyExistsAndOverwritePbfIsEnabled()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("runner-redownload-existing-pbf", false);
+        var options = CreateOptions(overwritePbf: true);
+        var sut = CreateSut(tempDir.DirectoryPath, options);
+
+        var regionsPath = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.RegionsJson));
+        TestFiles.WriteAllText(regionsPath, "[]");
+
+        var region = BerlinRegion();
+        _regionSource.GetRegionsAsync(regionsPath, Arg.Any<CancellationToken>())
+            .Returns(new[] { region });
+
+        var workDir = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.WorkDir));
+        var pbfPath = Path.Combine(workDir, region.Id, "osm.pbf");
+        TestFiles.WriteAllText(pbfPath, "existing pbf");
+
+        // Act
+        await sut.RunAsync(CancellationToken.None);
+
+        // Assert
+        await _fileDownloader.Received(1).DownloadAsync(region.PbfUrl, pbfPath, Arg.Any<CancellationToken>());
+        await _renderRegion.Received(1).RunAsync(
+            region,
+            workDir,
+            Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.OutDir)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_ProcessesOnlyMatchingRegion_WhenOnlyRegionIdIsConfigured()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("runner-only-region", false);
+        var options = CreateOptions(onlyRegionId: "berlin");
+        var sut = CreateSut(tempDir.DirectoryPath, options);
+
+        var regionsPath = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.RegionsJson));
+        TestFiles.WriteAllText(regionsPath, "[]");
+
+        var berlin = BerlinRegion();
+        var hamburg = new RegionDto(
+            Id: "hamburg",
+            Name: "Hamburg",
+            PbfUrl: "https://example.com/hamburg.osm.pbf",
+            Poly: "hamburg.poly");
+
+        _regionSource.GetRegionsAsync(regionsPath, Arg.Any<CancellationToken>())
+            .Returns(new[] { berlin, hamburg });
+
+        var workDir = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.WorkDir));
+        var outDir = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.OutDir));
+
+        // Act
+        await sut.RunAsync(CancellationToken.None);
+
+        // Assert
+        await _fileDownloader.Received(1).DownloadAsync(
+            berlin.PbfUrl,
+            Path.Combine(workDir, berlin.Id, "osm.pbf"),
+            Arg.Any<CancellationToken>());
+
+        await _renderRegion.Received(1).RunAsync(berlin, workDir, outDir, Arg.Any<CancellationToken>());
+        await _renderRegion.DidNotReceive().RunAsync(hamburg, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_ForwardsCancellationToken_ToCollaborators()
+    {
+        // Arrange
+        await using var tempDir = TestTemporaryDirectories.Create("runner-forwards-cancellation-token", false);
+        var options = CreateOptions();
+        var sut = CreateSut(tempDir.DirectoryPath, options);
+
+        var regionsPath = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.RegionsJson));
+        TestFiles.WriteAllText(regionsPath, "[]");
+
+        var region = BerlinRegion();
+        using var cts = new CancellationTokenSource();
+        var ct = cts.Token;
+
+        _regionSource.GetRegionsAsync(regionsPath, ct)
+            .Returns(new[] { region });
+
+        // Act
+        await sut.RunAsync(ct);
+
+        // Assert
+        await _regionSource.Received(1).GetRegionsAsync(regionsPath, ct);
+        await _fileDownloader.Received(1).DownloadAsync(
+            region.PbfUrl,
+            Arg.Any<string>(),
+            ct);
+        await _renderRegion.Received(1).RunAsync(
+            region,
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            ct);
+    }
+
+    private Runner CreateSut(
+        string contentRoot,
+        RendererOptions options)
+        => new(
+            new FakeHostEnvironment
+            {
+                ContentRootPath = contentRoot
+            },
+            NullLogger<Runner>.Instance,
+            _fileDownloader,
+            _regionSource,
+            _renderRegion,
+            Options.Create(options));
+
+    private static RendererOptions CreateOptions(
+        string workDir = "work",
+        string outDir = "out",
+        string regionsJson = "regions.json",
+        bool overwritePbf = false,
+        bool dryRun = false,
+        string? onlyRegionId = null)
+        => new()
+        {
+            WorkDir = workDir,
+            OutDir = outDir,
+            RegionsJson = regionsJson,
+            OverwritePbf = overwritePbf,
+            DryRun = dryRun,
+            OnlyRegionId = onlyRegionId,
+            DownloadTimeoutSeconds = 600
+        };
+
+    private static RegionDto BerlinRegion()
+        => new(
+            Id: "berlin",
+            Name: "Berlin",
+            PbfUrl: "https://example.com/berlin.osm.pbf",
+            Poly: "berlin.poly");
+
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "POIneer.Render.UnitTests";
+        public string ContentRootPath { get; set; } = "";
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
## 📋 Description

This pull request introduces several improvements and refactorings to the renderer application, primarily focusing on supporting overwrite modes for PBF and SQLite outputs, improving configuration handling, and enhancing testability. The changes ensure more robust and predictable behavior for file downloads and region rendering, and they standardize directory structures for region-specific data.

**Key changes include:**

### Overwrite and Download Behavior

* Added `OverwriteDatabase` and `OverwritePbf` options to `RendererOptions`, allowing users to control whether existing SQLite databases and PBF files are overwritten during rendering. These options are now respected throughout the codebase, including in the CLI runner and use case logic. (`[[1]](diffhunk://#diff-706c649e970dbe6dd1281c137817fcfe56bbdd069c0068f4e31b519b42a40f84R11-R19)`, `[[2]](diffhunk://#diff-d320dd6a9309435a1098592d0826b4d2a5806d916adcb6ed7d44f9015abc0f2fR36)`, `[[3]](diffhunk://#diff-d320dd6a9309435a1098592d0826b4d2a5806d916adcb6ed7d44f9015abc0f2fL76-R94)`, `[[4]](diffhunk://#diff-235939ad41a58d56642e820635ab4b79cb802374d8396e4ae935c743a136d5edL40-R47)`, `[[5]](diffhunk://#diff-235939ad41a58d56642e820635ab4b79cb802374d8396e4ae935c743a136d5edR70-R79)`)
* Updated the CLI and launch configuration to expose and document these overwrite options. (`.vscode/launch.json` [.vscode/launch.jsonR19-R20](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R19-R20))

### Configuration and Dependency Injection

* Refactored configuration loading to consistently use the `RendererOptions` class from the new `Application.Options` namespace, and ensured validation occurs at startup. (`[[1]](diffhunk://#diff-706c649e970dbe6dd1281c137817fcfe56bbdd069c0068f4e31b519b42a40f84L1-R1)`, `[[2]](diffhunk://#diff-b820e2528052797f89d5f7bd0b9b73c43d9b049d280851a7501eddd6aeb24f18R5-L9)`, `[[3]](diffhunk://#diff-b820e2528052797f89d5f7bd0b9b73c43d9b049d280851a7501eddd6aeb24f18L22-L59)`)
* Changed the HTTP client registration for file downloading to respect the `DownloadTimeoutSeconds` option, improving reliability for large downloads. (`[[1]](diffhunk://#diff-706c649e970dbe6dd1281c137817fcfe56bbdd069c0068f4e31b519b42a40f84R11-R19)`, `[[2]](diffhunk://#diff-b820e2528052797f89d5f7bd0b9b73c43d9b049d280851a7501eddd6aeb24f18L22-L59)`)

### File and Directory Structure

* Standardized the working directory layout so that each region has its own subdirectory, with PBFs and cut files stored as `workDir/{regionId}/osm.pbf` and `workDir/{regionId}/cut.osm.pbf` respectively. This affects both production and test code. (`[[1]](diffhunk://#diff-235939ad41a58d56642e820635ab4b79cb802374d8396e4ae935c743a136d5edL40-R47)`, `[[2]](diffhunk://#diff-d320dd6a9309435a1098592d0826b4d2a5806d916adcb6ed7d44f9015abc0f2fL76-R94)`, `[[3]](diffhunk://#diff-f2c9c683ec4867d03bbdfd19434c7d34fa48215c2e2629bf156c44b778025c22L81-R95)`, `[[4]](diffhunk://#diff-f2c9c683ec4867d03bbdfd19434c7d34fa48215c2e2629bf156c44b778025c22L137-R152)`, `[[5]](diffhunk://#diff-f2c9c683ec4867d03bbdfd19434c7d34fa48215c2e2629bf156c44b778025c22L193-R208)`)

### Code Quality and Testability

* Refactored and extended unit tests to use the new directory structure and options, including the introduction of helpers like `TestFiles` and `TestRendererOptions` for easier test setup. (`[[1]](diffhunk://#diff-1f192a3e37eb514dce90001b44479cf607063fa7e425ef32ca330e664ce150c6R1-R12)`, `[[2]](diffhunk://#diff-2330640724f22d8383c13e349c1137c5a879527654f42677f58af5bcc8d50f18R1-R18)`, `[[3]](diffhunk://#diff-f2c9c683ec4867d03bbdfd19434c7d34fa48215c2e2629bf156c44b778025c22L24-R41)`, `[[4]](diffhunk://#diff-f2c9c683ec4867d03bbdfd19434c7d34fa48215c2e2629bf156c44b778025c22L81-R95)`, `[[5]](diffhunk://#diff-f2c9c683ec4867d03bbdfd19434c7d34fa48215c2e2629bf156c44b778025c22L137-R152)`, `[[6]](diffhunk://#diff-f2c9c683ec4867d03bbdfd19434c7d34fa48215c2e2629bf156c44b778025c22L174-R191)`, `[[7]](diffhunk://#diff-f2c9c683ec4867d03bbdfd19434c7d34fa48215c2e2629bf156c44b778025c22L193-R208)`)
* Improved the `HttpFileDownloader` to stream downloads directly to disk, reducing memory usage for large files. (`[src/POIneer.Render/Adapters/Input/FileDownloader.csL12-R32](diffhunk://#diff-954c8c44590d66d5ce4e20a2d24ff0da0b086622dac5092b6c88192002d908e0L12-R32)`)

### Miscellaneous

* Added a new region ("Mittelfranken") to the sample regions file for local development. (`[src/POIneer.Render/Cli/config/regions.local.jsonR8-R14](diffhunk://#diff-a3350a8c92c66f63caf1b6ccc0ae960aa0af5a6f465736b2e714c0100bd3e6bdR8-R14)`)
* Minor cleanup of unused usings and configuration in various files. (`[[1]](diffhunk://#diff-748fd279338820afbb185aa7bac49c478bc9e1ef5a4d3b20f182c859c566e8b2L2)`, `[[2]](diffhunk://#diff-8e7399e73d9f8e52070fb8866900a0c3053ad647a63fdb5064653925e578d495L6-R6)`, `[[3]](diffhunk://#diff-235939ad41a58d56642e820635ab4b79cb802374d8396e4ae935c743a136d5edL4-R9)`, `[[4]](diffhunk://#diff-d320dd6a9309435a1098592d0826b4d2a5806d916adcb6ed7d44f9015abc0f2fL4-R4)`)

These changes collectively make the renderer more configurable, robust, and maintainable, especially for workflows that require repeated runs or large-scale data processing.

## 🔗 Related Issues

Closes #40

---

## 🧪 How to Test

1. --Renderer:OverwriteDatabase=false (default) => keep existing sqlite file (except: if pbf is recreated)
2. --Renderer:OverwriteDatabase=true => overwrites sqlite file
3. -- Renderer:OverwritePbf=false => keep existing file (or download if file does not exist)
4. -- Renderer:OverwritePbf=true => redownload if exists

---

## ✅ Checklist

* [ ] Code follows project conventions
* [ ] Self-review completed
* [ ] Tests added or updated (if applicable)
* [ ] All tests pass locally
* [ ] No breaking changes (or documented below)

---

## ⚠️ Breaking Changes

<!-- Describe breaking changes if any -->

* None

---

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
