### PR TITLE
feat: enhance RunnerTests to validate PBF download and existence

### DIFF
--- a/tests/POIneer.Render.UnitTests/Cli/RunnerTests.cs
+++ b/tests/POIneer.Render.UnitTests/Cli/RunnerTests.cs
@@ -76,12 +76,20 @@ public sealed class RunnerTests
         var workDir = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.WorkDir));
         var outDir = Path.GetFullPath(Path.Combine(tempDir.DirectoryPath, options.OutDir));
         var expectedPbfPath = Path.Combine(workDir, region.Id, "osm.pbf");
+        _fileDownloader
+            .DownloadAsync(region.PbfUrl, expectedPbfPath, Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                TestFiles.WriteAllText(expectedPbfPath, "downloaded pbf");
+                return Task.FromResult(expectedPbfPath);
+            });
 
         // Act
         var result = await sut.RunAsync(CancellationToken.None);
 
         // Assert
         result.Should().Be(0);
+        File.Exists(expectedPbfPath).Should().BeTrue();
         await _fileDownloader.Received(1).DownloadAsync(region.PbfUrl, expectedPbfPath, Arg.Any<CancellationToken>());
         await _renderRegion.Received(1).RunAsync(region, workDir, outDir, Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## 📋 Description

This pull request updates the `RunAsync_ResolvesRelativePathsAgainstContentRoot_AndProcessesR` unit test to improve test reliability by simulating file download behavior and verifying file creation.

Test improvements:

* Mocked the `_fileDownloader.DownloadAsync` method to simulate downloading by writing a test file to `expectedPbfPath`, ensuring the test environment closely mimics real behavior.
* Added an assertion to verify that the expected PBF file is created after running the method under test.
---

## 🔗 Related Issues

Closes #37 

---

## 🧪 How to Test

1. run renderer 
2. successfully downloaded pbf (work dir)
3. rerun: skip download if file already exists (eTag/modified not yet checked, out of scope for mvp)

---

## ✅ Checklist

* [ ] Code follows project conventions
* [ ] Self-review completed
* [ ] Tests added or updated (if applicable)
* [ ] All tests pass locally
* [ ] No breaking changes (or documented below)

---

## ⚠️ Breaking Changes

* None

---

