### PR TITLE
Bump dotnet-reportgenerator-globaltool from 5.5.9 to 5.5.10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.9",
+      "version": "5.5.10",
       "commands": [
         "reportgenerator"
       ],


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: dotnet-reportgenerator-globaltool dependency-version: 5.5.10 dependency-type: direct:production update-type: version-update:semver-patch ...

## 📋 Description

This pull request includes a minor update to the `dotnet-reportgenerator-globaltool` tool version in the `.config/dotnet-tools.json` file, upgrading it from version 5.5.9 to 5.5.10.
---


---

## ✅ Checklist

* [x] Code follows project conventions
* [x] Self-review completed
* [x] Tests added or updated (if applicable)
* [x] All tests pass locally
* [x] No breaking changes (or documented below)

---

## ⚠️ Breaking Changes

* None

---

## 📸 Screenshots (if applicable)

* None
