### PR TITLE
feat: add local run instructions and configuration details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,102 @@ When changing migrations or Flyway path handling:
 
 ---
 
+## ▶️ Run the Renderer
+
+Run the renderer locally:
+
+```bash
+dotnet run --project src/POIneer.Render
+```
+
+The renderer will:
+
+1. resolve configured regions
+2. download and process OSM data
+3. apply Flyway migrations
+4. extract POIs
+5. generate offline-ready SQLite databases
+
+Current MVP production configuration renders:
+
+- Berlin
+
+---
+
+## ⚙️ Configuration
+
+Configuration is loaded from:
+
+- `appsettings.json`
+- `appsettings.{Environment}.json`
+- environment variables
+- command line arguments
+
+Example:
+
+```json
+{
+  "Renderer": {
+    "OnlyRegionId": "berlin"
+  }
+}
+```
+
+Environment variables can override configuration values:
+
+```bash
+POINEER_RENDER__RENDERER__ONLYREGIONID=berlin
+```
+
+---
+
+## 📂 Output Structure
+
+Generated files are stored inside the configured data directories.
+
+Example structure:
+
+```text
+data/
+├─ dev/
+│  ├─ work/
+│  └─ out/
+└─ prod/
+   ├─ work/
+   └─ out/
+```
+
+Example generated database:
+
+```text
+data/prod/out/berlin/poi.sqlite
+```
+
+Temporary and intermediate files are written to the corresponding `work` directory.
+
+---
+
+## 🚧 MVP Status
+
+Current MVP capabilities:
+
+- regional OSM rendering
+- SQLite export
+- Flyway migrations
+- automated tests
+- Jenkins CI
+- configurable regions
+- offline-ready POI database generation
+
+Planned future features:
+
+- scheduled region updates
+- admin UI
+- API layer
+- mobile app integration
+- multi-region rendering
+- tile generation
+
 ## Development Notes
 
 - Follow the repository-specific guidance in `AGENTS.md` before making larger changes.


### PR DESCRIPTION
## 📋 Description

This pull request adds comprehensive documentation to the `README.md` for running and configuring the renderer, as well as details on output structure and current MVP status. These updates aim to help developers and users understand how to operate the renderer, customize its behavior, and interpret its outputs.

**Renderer usage and configuration:**

* Added instructions for running the renderer locally, including a step-by-step outline of what the renderer does (resolving regions, processing OSM data, applying migrations, extracting POIs, and generating SQLite databases).
* Documented configuration options, including sources (`appsettings.json`, environment variables, command line arguments), example configuration, and how to override settings with environment variables.

**Output and MVP status:**

* Described the output directory structure, with examples of generated files and explanation of where temporary and final outputs are stored.
* Added a section detailing current MVP features (regional OSM rendering, SQLite export, migrations, CI, etc.) and a roadmap of planned features.

---

## 🔗 Related Issues

Closes #41

---

## 🧪 How to Test

Run the renderer locally:

```bash
dotnet run --project src/POIneer.Render
```

The renderer will:

1. resolve configured regions
2. download and process OSM data
3. apply Flyway migrations
4. extract POIs
5. generate offline-ready SQLite databases

---

## ✅ Checklist

* [ ] Code follows project conventions
* [ ] Self-review completed
* [ ] Tests added or updated (if applicable)
* [ ] All tests pass locally
* [ ] No breaking changes (or documented below)

---

## ⚠️ Breaking Changes

* None

---

## 📸 Screenshots (if applicable)

* None
